### PR TITLE
fix: remove workbox-window requirement

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { registerSW } from 'virtual:pwa-register';
-
-registerSW();
+// Register the service worker without using the Vite PWA helper
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js');
+  });
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
+      injectRegister: false,
       includeAssets: ['icons/192.png', 'icons/512.png'],
       manifest: {
         name: 'Cyber Idle',


### PR DESCRIPTION
## Summary
- manually register service worker without `workbox-window`
- disable VitePWA's automatic register injection

## Testing
- `pnpm test` *(fails: ReferenceError: expect is not defined)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6896222a9958833181e777ea900dfe9b