### PR TITLE
Fix Vitest configuration and jest-dom setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest --run",
     "lint": "eslint .",
     "format": "prettier --write ."
   },

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "types": ["vitest/globals"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,9 +27,5 @@ export default defineConfig({
         ]
       }
     })
-  ],
-  test: {
-    environment: 'jsdom',
-    setupFiles: './src/test/setup.ts'
-  }
+  ]
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: true
+  }
+});


### PR DESCRIPTION
## Summary
- add Vitest config with jsdom environment, globals and CSS handling
- switch jest-dom import to @testing-library/jest-dom/vitest and run tests via `vitest --run`
- include Vitest global types in TypeScript config

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68962b57a3cc83318b3d16dbe90d69af