### PR TITLE
feat: add persistent game saves with IndexedDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "react": "^18.2.0",
+    "idb": "^7.1.1",
     "react-dom": "^18.2.0",
     "zustand": "^4.5.2"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,44 @@
+import { useEffect } from 'react';
 import AppShell from './ui/AppShell';
+import { loadGame, saveGame } from './game/save/save';
+import { useGameStore } from './game/state/store';
 
 function App() {
+  useEffect(() => {
+    loadGame().then((state) => {
+      if (state) {
+        useGameStore.setState(state);
+      }
+    });
+
+    const save = debounce(async () => {
+      const updated = await saveGame(useGameStore.getState());
+      useGameStore.setState(updated);
+    }, 500);
+
+    const interval = setInterval(save, 10000);
+    const onVisibility = () => {
+      if (document.hidden) {
+        save();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+
   return <AppShell />;
 }
 
 export default App;
+
+function debounce<T extends (...args: unknown[]) => void>(fn: T, delay: number) {
+  let timer: number | undefined;
+  return (...args: Parameters<T>) => {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(() => fn(...args), delay);
+  };
+}

--- a/src/game/save/save.ts
+++ b/src/game/save/save.ts
@@ -1,0 +1,83 @@
+import { GameState } from '../state/store';
+
+const DB_NAME = 'cyber-idle';
+const STORE_NAME = 'game';
+const SAVE_KEY = 'state';
+const SAVE_VERSION = 1;
+
+interface PersistedData {
+  version: number;
+  state: GameState;
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export async function loadGame(): Promise<GameState | null> {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(SAVE_KEY);
+    req.onsuccess = () => {
+      const data = req.result as PersistedData | undefined;
+      resolve(data ? data.state : null);
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function saveGame(state: GameState): Promise<GameState> {
+  const db = await openDatabase();
+  const withTimestamp: GameState = {
+    ...state,
+    meta: { ...state.meta, lastSavedAt: Date.now() },
+  };
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const req = tx
+      .objectStore(STORE_NAME)
+      .put({ version: SAVE_VERSION, state: withTimestamp }, SAVE_KEY);
+    req.onsuccess = () => resolve(withTimestamp);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function exportGame(): Promise<string> {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const req = tx.objectStore(STORE_NAME).get(SAVE_KEY);
+    req.onsuccess = () => {
+      const data = req.result as PersistedData | undefined;
+      resolve(JSON.stringify(data ?? { version: SAVE_VERSION, state: null }));
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export async function importGame(json: string): Promise<GameState> {
+  const data = JSON.parse(json) as PersistedData;
+  if (!data || typeof data.version !== 'number' || !data.state) {
+    throw new Error('Invalid save data');
+  }
+  await saveGame(data.state);
+  return data.state;
+}
+
+export async function clearGame(): Promise<void> {
+  const db = await openDatabase();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const req = tx.objectStore(STORE_NAME).delete(SAVE_KEY);
+    req.onsuccess = () => resolve();
+    req.onerror = () => reject(req.error);
+  });
+}

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -1,5 +1,21 @@
 import { create } from 'zustand';
 
-interface GameState {}
+export interface GameState {
+  player: { hp: number; credits: number; data: number };
+  skills: {
+    hacking: { level: number; xp: number };
+    combat: { level: number; xp: number };
+  };
+  meta: { lastSavedAt: number | null };
+}
 
-export const useGameStore = create<GameState>(() => ({}));
+export const initialState: GameState = {
+  player: { hp: 100, credits: 0, data: 0 },
+  skills: {
+    hacking: { level: 1, xp: 0 },
+    combat: { level: 1, xp: 0 },
+  },
+  meta: { lastSavedAt: null },
+};
+
+export const useGameStore = create<GameState>(() => initialState);

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -3,6 +3,8 @@ import HackingTab from './tabs/HackingTab';
 import CombatTab from './tabs/CombatTab';
 import InventoryTab from './tabs/InventoryTab';
 import UpgradesTab from './tabs/UpgradesTab';
+import SettingsMenu from './SettingsMenu';
+import { useGameStore } from '../game/state/store';
 
 type Tab = 'hacking' | 'combat' | 'inventory' | 'upgrades';
 
@@ -15,6 +17,7 @@ const tabs: { key: Tab; label: string }[] = [
 
 export default function AppShell() {
   const [current, setCurrent] = useState<Tab>('hacking');
+  const player = useGameStore((s) => s.player);
 
   const renderTab = () => {
     switch (current) {
@@ -32,8 +35,11 @@ export default function AppShell() {
   return (
     <div className="flex h-full flex-col bg-background">
       <header className="flex justify-between p-4 text-neon-cyan">
-        <span>Credits: 0</span>
-        <span>Data: 0</span>
+        <span>Credits: {player.credits}</span>
+        <div className="flex items-center gap-2">
+          <span>Data: {player.data}</span>
+          <SettingsMenu />
+        </div>
       </header>
       <main className="flex-1 overflow-y-auto" data-testid="tab-content">
         {renderTab()}

--- a/src/ui/SettingsMenu.tsx
+++ b/src/ui/SettingsMenu.tsx
@@ -1,0 +1,93 @@
+import { useRef, useState } from 'react';
+import {
+  exportGame,
+  importGame,
+  clearGame,
+} from '../game/save/save';
+import { useGameStore, initialState } from '../game/state/store';
+
+export default function SettingsMenu() {
+  const [open, setOpen] = useState(false);
+  const fileInput = useRef<HTMLInputElement>(null);
+
+  const handleExport = async () => {
+    try {
+      const json = await exportGame();
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'cyber-idle-save.json';
+      a.click();
+      URL.revokeObjectURL(url);
+      alert('Export successful');
+    } catch (err) {
+      console.error(err);
+      alert('Export failed');
+    }
+  };
+
+  const handleImport = () => {
+    fileInput.current?.click();
+  };
+
+  const onFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const state = await importGame(text);
+      useGameStore.setState(state);
+      alert('Import successful');
+    } catch (err) {
+      console.error(err);
+      alert('Import failed');
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  const handleClear = async () => {
+    if (!confirm('Clear saved game?')) return;
+    try {
+      await clearGame();
+      useGameStore.setState(initialState);
+      alert('Save cleared');
+    } catch (err) {
+      console.error(err);
+      alert('Failed to clear save');
+    }
+  };
+
+  return (
+    <div className="relative text-white">
+      <button
+        aria-label="Settings"
+        onClick={() => setOpen((o) => !o)}
+        className="px-2"
+      >
+        ⚙
+      </button>
+      {open && (
+        <div className="absolute right-0 mt-2 flex flex-col bg-gray-800 p-2 text-sm shadow">
+          <button className="mb-1 text-left" onClick={handleExport}>
+            Export Save
+          </button>
+          <button className="mb-1 text-left" onClick={handleImport}>
+            Import Save
+          </button>
+          <button className="text-left" onClick={handleClear}>
+            Clear Save
+          </button>
+        </div>
+      )}
+      <input
+        ref={fileInput}
+        type="file"
+        accept="application/json"
+        className="hidden"
+        onChange={onFileChange}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- store game state in IndexedDB and expose load, save, export, import, clear helpers
- add autosave with debounce and visibility change handling
- add settings menu for exporting, importing, and clearing saves

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68962e062918833187ddcac6ddd9468a