### PR TITLE
feat: add basic combat system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,12 @@ function App() {
   useEffect(() => {
     loadGame().then((state) => {
       if (state) {
+        if (state.combat?.inFight) {
+          state = {
+            ...state,
+            combat: { enemyId: null, enemyHp: 0, inFight: false, log: [] },
+          };
+        }
         useGameStore.setState(state);
       }
     });

--- a/src/data/enemies.json
+++ b/src/data/enemies.json
@@ -1,0 +1,6 @@
+[
+  { "id":"thug","name":"Alley Thug","level":1,"hp":25,"atk":4,"def":1,"xp":12,
+    "loot":[{"credits":true,"min":3,"max":8},{"itemId":"scrap","chance":0.6,"min":1,"max":2}] },
+  { "id":"drone","name":"Corp Drone","level":2,"hp":35,"atk":6,"def":2,"xp":18,
+    "loot":[{"credits":true,"min":6,"max":14},{"itemId":"microchip","chance":0.5,"min":1,"max":1}] }
+]

--- a/src/game/combat.test.ts
+++ b/src/game/combat.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { attack, calcDamage, startCombat } from './combat';
+import { useGameStore, initialState } from './state/store';
+
+describe('combat system', () => {
+  beforeEach(() => {
+    useGameStore.setState(initialState);
+  });
+
+  it('damage formula returns at least 1', () => {
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.5); // variance 0
+    const dmg = calcDamage(1, 100);
+    expect(dmg).toBeGreaterThanOrEqual(1);
+    spy.mockRestore();
+  });
+
+  it('winning a fight grants rewards', () => {
+    const rand = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0) // player damage variance
+      .mockReturnValueOnce(0) // credits roll
+      .mockReturnValueOnce(0) // item drop chance
+      .mockReturnValueOnce(0); // item quantity
+
+    useGameStore.setState((s) => ({
+      ...initialState,
+      player: { ...initialState.player, atk: 50 },
+    }));
+
+    startCombat('thug');
+    attack();
+
+    const state = useGameStore.getState();
+    expect(state.skills.combat.xp).toBe(12);
+    expect(state.player.credits).toBeGreaterThan(0);
+    expect(state.inventory.scrap).toBe(1);
+
+    rand.mockRestore();
+  });
+});

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -1,0 +1,142 @@
+import { useGameStore } from './state/store';
+import enemiesData from '../data/enemies.json';
+
+export type Enemy = (typeof enemiesData)[number];
+
+export const enemies: Enemy[] = enemiesData;
+
+export function getEnemy(id: string): Enemy | undefined {
+  return enemies.find((e) => e.id === id);
+}
+
+function randRange(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+export function calcDamage(atk: number, def: number): number {
+  const variance = randRange(-1, 1);
+  return Math.max(1, atk + variance - def);
+}
+
+function trimLog(log: string[]): string[] {
+  return log.slice(-10);
+}
+
+export function startCombat(enemyId: string) {
+  const enemy = getEnemy(enemyId);
+  if (!enemy) return;
+  useGameStore.setState((s) => ({
+    ...s,
+    combat: {
+      enemyId,
+      enemyHp: enemy.hp,
+      inFight: true,
+      log: [`Engaged ${enemy.name}`],
+    },
+  }));
+}
+
+function rollLoot(enemy: Enemy) {
+  let credits = 0;
+  const items: Record<string, number> = {};
+  for (const entry of enemy.loot) {
+    if (entry.credits) {
+      credits += randRange(entry.min, entry.max);
+    } else if (entry.itemId) {
+      if (Math.random() < (entry.chance ?? 1)) {
+        const qty = randRange(entry.min, entry.max);
+        items[entry.itemId] = (items[entry.itemId] ?? 0) + qty;
+      }
+    }
+  }
+  return { credits, items };
+}
+
+function awardVictory(enemy: Enemy, log: string[]) {
+  useGameStore.setState((state) => {
+    const rewards = rollLoot(enemy);
+    const inv = { ...state.inventory };
+    for (const [itemId, qty] of Object.entries(rewards.items)) {
+      inv[itemId] = (inv[itemId] ?? 0) + qty;
+      log.push(`Looted ${qty} ${itemId}`);
+    }
+    let { level, xp } = state.skills.combat;
+    xp += enemy.xp;
+    while (xp >= level * 100) {
+      xp -= level * 100;
+      level += 1;
+    }
+    const newPlayer = {
+      ...state.player,
+      credits: state.player.credits + rewards.credits,
+    };
+    if (rewards.credits > 0) {
+      log.push(`Gained ${rewards.credits} credits`);
+    }
+    log.push(`Defeated ${enemy.name}`);
+    return {
+      ...state,
+      player: newPlayer,
+      skills: { ...state.skills, combat: { level, xp } },
+      inventory: inv,
+      combat: { enemyId: null, enemyHp: 0, inFight: false, log: trimLog(log) },
+    };
+  });
+}
+
+export function attack() {
+  const state = useGameStore.getState();
+  if (!state.combat.inFight || !state.combat.enemyId) return;
+  const enemy = getEnemy(state.combat.enemyId);
+  if (!enemy) return;
+  let enemyHp = state.combat.enemyHp;
+  const log = [...state.combat.log];
+
+  const dmgToEnemy = calcDamage(state.player.atk, enemy.def);
+  enemyHp -= dmgToEnemy;
+  log.push(`You hit ${enemy.name} for ${dmgToEnemy}`);
+
+  if (enemyHp <= 0) {
+    awardVictory(enemy, log);
+    return;
+  }
+
+  const dmgToPlayer = calcDamage(enemy.atk, state.player.def);
+  const playerHp = state.player.hp - dmgToPlayer;
+  log.push(`${enemy.name} hits you for ${dmgToPlayer}`);
+
+  if (playerHp <= 0) {
+    log.push('You were defeated');
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, hp: 1 },
+      combat: { enemyId: null, enemyHp: 0, inFight: false, log: trimLog(log) },
+    }));
+    return;
+  }
+
+  useGameStore.setState((s) => ({
+    ...s,
+    player: { ...s.player, hp: playerHp },
+    combat: { ...s.combat, enemyHp, log: trimLog(log) },
+  }));
+}
+
+export function flee() {
+  useGameStore.setState((s) => ({
+    ...s,
+    combat: {
+      enemyId: null,
+      enemyHp: 0,
+      inFight: false,
+      log: trimLog([...s.combat.log, 'Fled from battle']),
+    },
+  }));
+}
+
+export function quickHeal() {
+  useGameStore.setState((s) => ({
+    ...s,
+    player: { ...s.player, hp: s.player.hpMax },
+  }));
+}

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -1,20 +1,43 @@
 import { create } from 'zustand';
 
 export interface GameState {
-  player: { hp: number; credits: number; data: number };
+  player: {
+    hpMax: number;
+    hp: number;
+    atk: number;
+    def: number;
+    credits: number;
+    data: number;
+  };
   skills: {
     hacking: { level: number; xp: number };
     combat: { level: number; xp: number };
+  };
+  inventory: { [itemId: string]: number };
+  combat: {
+    enemyId: string | null;
+    enemyHp: number;
+    inFight: boolean;
+    log: string[];
   };
   meta: { lastSavedAt: number | null };
 }
 
 export const initialState: GameState = {
-  player: { hp: 100, credits: 0, data: 0 },
+  player: {
+    hpMax: 50,
+    hp: 50,
+    atk: 5,
+    def: 2,
+    credits: 0,
+    data: 0,
+  },
   skills: {
     hacking: { level: 1, xp: 0 },
     combat: { level: 1, xp: 0 },
   },
+  inventory: {},
+  combat: { enemyId: null, enemyHp: 0, inFight: false, log: [] },
   meta: { lastSavedAt: null },
 };
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -7,6 +7,6 @@ describe('AppShell', () => {
     expect(screen.getByText('Credits: 0')).toBeInTheDocument();
     expect(screen.getByTestId('tab-content')).toHaveTextContent('Start hack');
     fireEvent.click(screen.getByRole('button', { name: 'Combat' }));
-    expect(screen.getByTestId('tab-content')).toHaveTextContent('Combat');
+    expect(screen.getByRole('button', { name: 'Engage' })).toBeInTheDocument();
   });
 });

--- a/src/ui/tabs/CombatTab.tsx
+++ b/src/ui/tabs/CombatTab.tsx
@@ -1,3 +1,63 @@
+import { useState } from 'react';
+import {
+  attack,
+  flee,
+  quickHeal,
+  startCombat,
+  enemies,
+  getEnemy,
+} from '../../game/combat';
+import { useGameStore } from '../../game/state/store';
+
 export default function CombatTab() {
-  return <div className="p-4">Combat</div>;
+  const combat = useGameStore((s) => s.combat);
+  const player = useGameStore((s) => s.player);
+  const [selected, setSelected] = useState(enemies[0]?.id ?? '');
+
+  const enemy = combat.enemyId ? getEnemy(combat.enemyId) : null;
+
+  return (
+    <div className="space-y-4 p-4">
+      {!combat.inFight ? (
+        <div className="space-y-4">
+          <div>
+            <select
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+              className="bg-black"
+            >
+              {enemies.map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <button onClick={() => startCombat(selected)} disabled={!selected}>
+            Engage
+          </button>
+          <button onClick={quickHeal}>Quick Heal</button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div>
+            Player HP: {player.hp} / {player.hpMax}
+          </div>
+          <div>
+            {enemy?.name} HP: {combat.enemyHp} / {enemy?.hp}
+          </div>
+          <div className="space-y-1">
+            {combat.log.map((l, i) => (
+              <div key={i}>{l}</div>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button onClick={attack}>Attack</button>
+            <button onClick={flee}>Flee</button>
+            <button onClick={quickHeal}>Quick Heal</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- define tier-1 enemies and combat data
- extend game state with combat, inventory, and player stats
- implement simple turn-based combat with rewards and UI controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971227c0008331911066cf874df27e