### PR TITLE
feat: add basic upgrade system

### DIFF
--- a/src/data/upgrades.json
+++ b/src/data/upgrades.json
@@ -1,0 +1,5 @@
+[
+  { "id":"hack_speed_1","name":"+5% Hacking Speed","costCredits":50,"costData":10,"effects":{"hackingSpeed":1.05} },
+  { "id":"atk_1","name":"+1 Attack","costCredits":60,"effects":{"atk":1} },
+  { "id":"hp_1","name":"+10 Max HP","costCredits":40,"effects":{"hpMax":10} }
+]

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -13,6 +13,8 @@ export interface GameState {
     hacking: { level: number; xp: number };
     combat: { level: number; xp: number };
   };
+  hacking: { timeMultiplier: number };
+  upgrades: { owned: Record<string, boolean> };
   inventory: { [itemId: string]: number };
   combat: {
     enemyId: string | null;
@@ -36,6 +38,8 @@ export const initialState: GameState = {
     hacking: { level: 1, xp: 0 },
     combat: { level: 1, xp: 0 },
   },
+  hacking: { timeMultiplier: 1 },
+  upgrades: { owned: {} },
   inventory: {},
   combat: { enemyId: null, enemyHp: 0, inFight: false, log: [] },
   meta: { lastSavedAt: null },

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -5,6 +5,7 @@ import InventoryTab from './tabs/InventoryTab';
 import UpgradesTab from './tabs/UpgradesTab';
 import SettingsMenu from './SettingsMenu';
 import { useGameStore } from '../game/state/store';
+import { NeonToast } from './Toast';
 
 type Tab = 'hacking' | 'combat' | 'inventory' | 'upgrades';
 
@@ -34,6 +35,7 @@ export default function AppShell() {
 
   return (
     <div className="flex h-full flex-col bg-background">
+      <NeonToast />
       <header className="flex justify-between p-4 text-neon-cyan">
         <span>Credits: {player.credits}</span>
         <div className="flex items-center gap-2">

--- a/src/ui/Toast.tsx
+++ b/src/ui/Toast.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+let trigger: ((msg: string) => void) | null = null;
+
+export function NeonToast() {
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    trigger = (msg: string) => {
+      setMessage(msg);
+      setTimeout(() => setMessage(null), 3000);
+    };
+  }, []);
+
+  if (!message) return null;
+
+  return (
+    <div className="fixed top-4 right-4 bg-neon-magenta px-4 py-2 text-black">
+      {message}
+    </div>
+  );
+}
+
+export function showToast(msg: string) {
+  trigger?.(msg);
+}

--- a/src/ui/tabs/HackingTab.tsx
+++ b/src/ui/tabs/HackingTab.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useGameStore } from '../../game/state/store';
 
-const HACK_DURATION = 10000; // ms
+const BASE_HACK_DURATION = 10000; // ms
 
 export default function HackingTab() {
   const hacking = useGameStore((s) => s.skills.hacking);
+  const timeMultiplier = useGameStore((s) => s.hacking.timeMultiplier);
   const setState = useGameStore.setState;
 
   const [inProgress, setInProgress] = useState(false);
@@ -13,13 +14,14 @@ export default function HackingTab() {
   useEffect(() => {
     if (!inProgress) return;
 
+    const duration = BASE_HACK_DURATION / timeMultiplier;
     const start = Date.now();
     const interval = setInterval(() => {
       const elapsed = Date.now() - start;
-      const pct = Math.min((elapsed / HACK_DURATION) * 100, 100);
+      const pct = Math.min((elapsed / duration) * 100, 100);
       setProgress(pct);
 
-      if (elapsed >= HACK_DURATION) {
+      if (elapsed >= duration) {
         clearInterval(interval);
 
         const rewardCredits = 50 + Math.floor(Math.random() * 101); // 50-150
@@ -52,7 +54,7 @@ export default function HackingTab() {
     }, 100);
 
     return () => clearInterval(interval);
-  }, [inProgress, setState]);
+  }, [inProgress, setState, timeMultiplier]);
 
   const xpNeeded = hacking.level * 100;
 

--- a/src/ui/tabs/UpgradesTab.test.tsx
+++ b/src/ui/tabs/UpgradesTab.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import UpgradesTab from './UpgradesTab';
+import HackingTab from './HackingTab';
+import { useGameStore, initialState } from '../../game/state/store';
+
+describe('Upgrades', () => {
+  beforeEach(() => {
+    useGameStore.setState(initialState);
+  });
+
+  it('buying hack_speed_1 reduces hack duration', () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, credits: 100, data: 100 },
+    }));
+
+    render(<UpgradesTab />);
+    fireEvent.click(screen.getByTestId('buy-hack_speed_1'));
+
+    render(<HackingTab />);
+    fireEvent.click(screen.getByRole('button', { name: /start hack/i }));
+
+    act(() => {
+      vi.advanceTimersByTime(9500);
+    });
+    expect(useGameStore.getState().player.credits).toBe(50);
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(useGameStore.getState().player.credits).toBe(100);
+
+    vi.useRealTimers();
+  });
+
+  it('buying atk_1 increases atk by 1', () => {
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, credits: 100 },
+    }));
+
+    render(<UpgradesTab />);
+    fireEvent.click(screen.getByTestId('buy-atk_1'));
+    expect(useGameStore.getState().player.atk).toBe(6);
+  });
+
+  it('buying hp_1 increases hpMax by 10 and heals to full', () => {
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, credits: 100, hp: 10 },
+    }));
+
+    render(<UpgradesTab />);
+    fireEvent.click(screen.getByTestId('buy-hp_1'));
+    const state = useGameStore.getState();
+    expect(state.player.hpMax).toBe(60);
+    expect(state.player.hp).toBe(60);
+  });
+});

--- a/src/ui/tabs/UpgradesTab.tsx
+++ b/src/ui/tabs/UpgradesTab.tsx
@@ -1,3 +1,89 @@
+import upgradesData from '../../data/upgrades.json';
+import { useGameStore } from '../../game/state/store';
+import { showToast } from '../Toast';
+
+interface Upgrade {
+  id: string;
+  name: string;
+  costCredits?: number;
+  costData?: number;
+  effects: {
+    hackingSpeed?: number;
+    atk?: number;
+    hpMax?: number;
+  };
+}
+
+const upgrades: Upgrade[] = upgradesData as Upgrade[];
+
 export default function UpgradesTab() {
-  return <div className="p-4">Upgrades</div>;
+  const player = useGameStore((s) => s.player);
+  const owned = useGameStore((s) => s.upgrades.owned);
+  const setState = useGameStore.setState;
+
+  const canAfford = (u: Upgrade) => {
+    if (u.costCredits && player.credits < u.costCredits) return false;
+    if (u.costData && player.data < u.costData) return false;
+    return true;
+  };
+
+  const buy = (u: Upgrade) => {
+    setState((state) => {
+      if (state.upgrades.owned[u.id]) return state;
+      if (!canAfford(u)) return state;
+      const newPlayer = { ...state.player };
+      if (u.costCredits) newPlayer.credits -= u.costCredits;
+      if (u.costData) newPlayer.data -= u.costData;
+      if (u.effects.atk) newPlayer.atk += u.effects.atk;
+      if (u.effects.hpMax) {
+        newPlayer.hpMax += u.effects.hpMax;
+        newPlayer.hp = newPlayer.hpMax;
+      }
+      const newHacking = { ...state.hacking };
+      if (u.effects.hackingSpeed) {
+        newHacking.timeMultiplier *= u.effects.hackingSpeed;
+      }
+      return {
+        ...state,
+        player: newPlayer,
+        hacking: newHacking,
+        upgrades: {
+          owned: { ...state.upgrades.owned, [u.id]: true },
+        },
+      };
+    });
+    showToast(`Purchased: ${u.name}`);
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <p className="text-sm text-neon-cyan">
+        Upgrades are permanent and automatically applied.
+      </p>
+      <ul className="space-y-2">
+        {upgrades.map((u) => {
+          const isOwned = owned[u.id];
+          const disabled = isOwned || !canAfford(u);
+          return (
+            <li key={u.id} className="flex items-center justify-between">
+              <div>
+                <div>{u.name}</div>
+                <div className="text-sm text-neon-cyan">
+                  {u.costCredits ? `Credits: ${u.costCredits} ` : ''}
+                  {u.costData ? `Data: ${u.costData}` : ''}
+                </div>
+              </div>
+              <button
+                data-testid={`buy-${u.id}`}
+                onClick={() => buy(u)}
+                disabled={disabled}
+              >
+                {isOwned ? 'Owned' : 'Buy'}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add starter upgrade data and tracking
- implement Upgrades tab with purchase flow and permanent effects
- apply hacking speed multiplier to reduce action time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689714cd4f7883318da60fba731561a2