### PR TITLE
feat: add core game data definitions

### DIFF
--- a/src/data/enemies.ts
+++ b/src/data/enemies.ts
@@ -1,6 +1,6 @@
-export interface DropEntry {
+export interface EnemyDrop {
   itemId: string;
-  dropChance: number; // 0-1
+  chance: number;
 }
 
 export interface Enemy {
@@ -8,76 +8,28 @@ export interface Enemy {
   name: string;
   hp: number;
   atk: number;
-  description: string;
-  dropTable: DropEntry[];
+  possibleDrops: EnemyDrop[];
+  creditsDrop?: { min: number; max: number };
+  description?: string;
 }
 
 export const enemies: Enemy[] = [
   {
     id: 'street_thug',
     name: 'Street Thug',
-    hp: 50,
-    atk: 5,
-    description: 'A low-level punk looking for trouble.',
-    dropTable: [
-      { itemId: 'small_credchip', dropChance: 0.6 },
-      { itemId: 'medkit', dropChance: 0.2 },
-    ],
+    hp: 20,
+    atk: 3,
+    possibleDrops: [{ itemId: 'knife_rusty', chance: 0.2 }],
+    creditsDrop: { min: 5, max: 15 },
+    description: 'A desperate punk looking for cash.',
   },
   {
-    id: 'data_leech',
-    name: 'Data Leech',
-    hp: 40,
-    atk: 8,
-    description: 'A scavenger that feeds on unsecured data.',
-    dropTable: [
-      { itemId: 'small_credchip', dropChance: 0.5 },
-      { itemId: 'energy_cell', dropChance: 0.15 },
-    ],
-  },
-  {
-    id: 'cyber_bruiser',
-    name: 'Cyber Bruiser',
-    hp: 70,
-    atk: 10,
-    description: 'Heavily augmented street fighter.',
-    dropTable: [
-      { itemId: 'small_credchip', dropChance: 0.3 },
-      { itemId: 'medkit', dropChance: 0.25 },
-    ],
-  },
-  {
-    id: 'rogue_drone',
-    name: 'Rogue Drone',
-    hp: 60,
-    atk: 9,
-    description: 'Autonomous drone gone haywire.',
-    dropTable: [
-      { itemId: 'energy_cell', dropChance: 0.3 },
-      { itemId: 'small_credchip', dropChance: 0.4 },
-    ],
-  },
-  {
-    id: 'netrunner',
-    name: 'Netrunner',
-    hp: 45,
-    atk: 7,
-    description: 'A hacker defending their turf.',
-    dropTable: [
-      { itemId: 'large_credchip', dropChance: 0.4 },
-      { itemId: 'data_fragment', dropChance: 0.2 },
-    ],
-  },
-  {
-    id: 'ice_program',
-    name: 'ICE Program',
-    hp: 55,
-    atk: 9,
-    description: 'Defensive security algorithm made manifest.',
-    dropTable: [
-      { itemId: 'data_fragment', dropChance: 0.25 },
-      { itemId: 'energy_cell', dropChance: 0.2 },
-    ],
+    id: 'cyber_rat',
+    name: 'Cyber Rat',
+    hp: 15,
+    atk: 2,
+    possibleDrops: [{ itemId: 'medkit_small', chance: 0.05 }],
+    creditsDrop: { min: 1, max: 5 },
   },
 ];
 

--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,63 +1,52 @@
-export type ItemType = 'weapon' | 'armor' | 'accessory' | 'consumable' | 'currency' | 'quest';
-
 export interface Item {
   id: string;
   name: string;
-  type: ItemType;
-  rarity: 'common' | 'uncommon' | 'rare';
+  type: 'weapon' | 'armor' | 'accessory' | 'consumable';
   source: 'loot-only' | 'shop-only' | 'both';
-  effect?: {
-    hp?: number; // amount of HP to heal
-    energy?: number; // future use
-  };
-  value?: number; // credit value for currency items
+  rarity?: 'common' | 'uncommon' | 'rare' | 'epic';
   description?: string;
+  iconText?: string; // placeholder symbol
+  stats?: { atk?: number; hpMax?: number; hackingSpeed?: number };
+  effect?: { heal?: number };
+  priceCredits?: number;
 }
 
 export const items: Item[] = [
   {
-    id: 'medkit',
-    name: 'Medkit',
-    type: 'consumable',
-    rarity: 'common',
+    id: 'knife_rusty',
+    name: 'Rusty Knife',
+    type: 'weapon',
     source: 'loot-only',
-    effect: { hp: 50 },
-    description: 'Heals 50 HP',
+    stats: { atk: 2 },
+    rarity: 'common',
+    iconText: '🗡',
   },
   {
-    id: 'small_credchip',
-    name: 'Small Credchip',
-    type: 'currency',
-    rarity: 'common',
-    source: 'loot-only',
-    value: 100,
-    description: 'A small cache of credits worth 100',
+    id: 'medkit_small',
+    name: 'Medkit (S)',
+    type: 'consumable',
+    source: 'shop-only',
+    effect: { heal: 50 },
+    priceCredits: 50,
+    iconText: '💊',
   },
   {
-    id: 'energy_cell',
-    name: 'Energy Cell',
-    type: 'consumable',
-    rarity: 'common',
+    id: 'jacket_leather',
+    name: 'Leather Jacket',
+    type: 'armor',
     source: 'both',
-    effect: { hp: 30, energy: 10 },
-    description: 'Heals 30 HP and restores 10 energy',
-  },
-  {
-    id: 'large_credchip',
-    name: 'Large Credchip',
-    type: 'currency',
+    stats: { hpMax: 10 },
     rarity: 'uncommon',
-    source: 'loot-only',
-    value: 500,
-    description: 'Valuable credit cache worth 500',
+    iconText: '🛡',
   },
   {
-    id: 'data_fragment',
-    name: 'Data Fragment',
-    type: 'quest',
-    rarity: 'rare',
+    id: 'ring_data',
+    name: 'Data Ring',
+    type: 'accessory',
     source: 'loot-only',
-    description: 'Encrypted data needed for missions',
+    stats: { hackingSpeed: 0.05 },
+    rarity: 'rare',
+    iconText: '💍',
   },
 ];
 

--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -1,36 +1,30 @@
+export interface LocationLoot {
+  itemId: string;
+  chance: number;
+}
+
 export interface Location {
   id: string;
   name: string;
-  description: string;
-  enemies: string[]; // enemy ids
-  loot: string[]; // item ids
-  encounterRates: { enemy: number; loot: number };
+  enemies: string[]; // enemy IDs
+  loot?: LocationLoot[];
+  description?: string;
 }
 
 export const locations: Location[] = [
   {
-    id: 'neon_street',
-    name: 'Neon Street',
-    description: 'The city\'s bustling thoroughfare.',
-    enemies: ['street_thug', 'data_leech'],
-    loot: ['medkit', 'small_credchip'],
-    encounterRates: { enemy: 0.99, loot: 0.01 },
+    id: 'dark_alley',
+    name: 'Dark Alley',
+    enemies: ['street_thug'],
+    loot: [{ itemId: 'medkit_small', chance: 0.01 }],
+    description: 'A shadowy alley where muggers lurk.',
   },
   {
-    id: 'abandoned_factory',
-    name: 'Abandoned Factory',
-    description: 'Derelict industrial complex crawling with dangers.',
-    enemies: ['cyber_bruiser', 'rogue_drone'],
-    loot: ['medkit', 'energy_cell'],
-    encounterRates: { enemy: 0.9, loot: 0.1 },
-  },
-  {
-    id: 'darkgrid_network',
-    name: 'Darkgrid Network',
-    description: 'Hidden nodes of the underground net.',
-    enemies: ['netrunner', 'ice_program'],
-    loot: ['large_credchip', 'data_fragment'],
-    encounterRates: { enemy: 0.8, loot: 0.2 },
+    id: 'abandoned_warehouse',
+    name: 'Abandoned Warehouse',
+    enemies: ['street_thug', 'cyber_rat'],
+    loot: [{ itemId: 'knife_rusty', chance: 0.05 }],
+    description: 'Dusty building with hidden corners.',
   },
 ];
 

--- a/src/data/upgrades.json
+++ b/src/data/upgrades.json
@@ -1,5 +1,0 @@
-[
-  { "id":"hack_speed_1","name":"+5% Hacking Speed","costCredits":50,"costData":10,"effects":{"hackingSpeed":1.05} },
-  { "id":"atk_1","name":"+1 Attack","costCredits":60,"effects":{"atk":1} },
-  { "id":"hp_1","name":"+10 Max HP","costCredits":40,"effects":{"hpMax":10} }
-]

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -1,0 +1,39 @@
+export interface Upgrade {
+  id: string;
+  name: string;
+  costCredits: number;
+  effects: { atk?: number; hpMax?: number; hackingSpeed?: number };
+  description?: string;
+  iconText?: string;
+}
+
+export const upgrades: Upgrade[] = [
+  {
+    id: 'neuro_patch_1',
+    name: 'Neuro Patch I',
+    costCredits: 120,
+    effects: { hackingSpeed: 1.05 },
+    description: 'Boosts neural signal processing by 5%.',
+    iconText: '🧠',
+  },
+  {
+    id: 'muscle_fiber_1',
+    name: 'Muscle Fiber Mesh',
+    costCredits: 100,
+    effects: { atk: 1 },
+    description: 'Synthetic fibers enhance strength.',
+    iconText: '💪',
+  },
+  {
+    id: 'dermal_plating_1',
+    name: 'Dermal Plating I',
+    costCredits: 80,
+    effects: { hpMax: 10 },
+    description: 'Reinforced skin grafts improve survivability.',
+    iconText: '🛡',
+  },
+];
+
+export function getUpgrade(id: string): Upgrade | undefined {
+  return upgrades.find((u) => u.id === id);
+}

--- a/src/game/combat.test.ts
+++ b/src/game/combat.test.ts
@@ -27,8 +27,8 @@ describe('combat system', () => {
 
     const state = useGameStore.getState();
     expect(state.skills.combat.xp).toBe(10);
-    expect(state.player.credits).toBe(100);
-    expect(state.inventory).toContain('medkit');
+    expect(state.player.credits).toBe(5);
+    expect(state.inventory).toContain('knife_rusty');
 
     rand.mockRestore();
   });
@@ -53,7 +53,7 @@ describe('combat system', () => {
     const rand = vi.spyOn(Math, 'random').mockReturnValue(0.5);
     useGameStore.setState(() => ({
       ...initialState,
-      player: { ...initialState.player, hp: 2, credits: 100 },
+      player: { ...initialState.player, hp: 1, credits: 100 },
     }));
     startCombat('street_thug');
     attack();

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -27,8 +27,8 @@ export function startCombat(enemyId: string) {
 
 function rollLoot(enemy: Enemy): string[] {
   const drops: string[] = [];
-  for (const entry of enemy.dropTable) {
-    if (Math.random() < entry.dropChance) {
+  for (const entry of enemy.possibleDrops) {
+    if (Math.random() < entry.chance) {
       drops.push(entry.itemId);
     }
   }
@@ -38,16 +38,17 @@ function rollLoot(enemy: Enemy): string[] {
 function awardVictory(enemy: Enemy, log: string[]) {
   useGameStore.setState((state) => {
     const drops = rollLoot(enemy);
-    const inventory = [...state.inventory];
+    const inventory = [...state.inventory, ...drops];
     const player = { ...state.player };
     for (const itemId of drops) {
       const item = getItem(itemId);
-      if (item?.type === 'currency') {
-        player.credits += item.value ?? 0;
-      } else {
-        inventory.push(itemId);
-      }
       log.push(`Looted ${item?.name ?? itemId}`);
+    }
+    if (enemy.creditsDrop) {
+      const { min, max } = enemy.creditsDrop;
+      const credits = Math.floor(Math.random() * (max - min + 1)) + min;
+      player.credits += credits;
+      log.push(`Looted ${credits} credits`);
     }
     let { level, xp } = state.skills.combat;
     xp += 10; // placeholder xp per victory

--- a/src/game/exploration.test.ts
+++ b/src/game/exploration.test.ts
@@ -6,7 +6,7 @@ import { getItem } from '../data/items';
 describe('exploration', () => {
   beforeEach(() => {
     useGameStore.setState(initialState);
-    setLocation('neon_street');
+    setLocation('dark_alley');
   });
 
   it('triggers enemy encounter', () => {
@@ -19,14 +19,16 @@ describe('exploration', () => {
   });
 
   it('can find loot-only items', () => {
-    const rand = vi.spyOn(Math, 'random')
-      .mockReturnValueOnce(0.995) // encounter roll -> loot
-      .mockReturnValue(0.6); // item selection -> second item (small_credchip)
+    setLocation('abandoned_warehouse');
+    const rand = vi
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.99) // enemy roll -> loot path
+      .mockReturnValueOnce(0); // loot chance success
     const result = explore();
     expect(result?.type).toBe('loot');
     const state = useGameStore.getState();
-    expect(state.player.credits).toBe(100); // small_credchip adds credits
-    const item = getItem('small_credchip');
+    expect(state.inventory).toContain('knife_rusty');
+    const item = getItem('knife_rusty');
     expect(item?.source).toBe('loot-only');
     rand.mockRestore();
   });

--- a/src/game/exploration.ts
+++ b/src/game/exploration.ts
@@ -13,15 +13,18 @@ export function explore() {
   const loc = getLocation(state.location);
   if (!loc) return null;
   const roll = Math.random();
-  if (roll < loc.encounterRates.enemy) {
+  if (loc.enemies.length && roll < 0.8) {
     const enemyId = loc.enemies[Math.floor(Math.random() * loc.enemies.length)];
     startCombat(enemyId);
     return { type: 'enemy', enemyId } as const;
   }
-  if (roll < loc.encounterRates.enemy + loc.encounterRates.loot) {
-    const itemId = loc.loot[Math.floor(Math.random() * loc.loot.length)];
-    addItemToInventory(itemId);
-    return { type: 'loot', itemId } as const;
+  if (loc.loot) {
+    for (const entry of loc.loot) {
+      if (Math.random() < entry.chance) {
+        addItemToInventory(entry.itemId);
+        return { type: 'loot', itemId: entry.itemId } as const;
+      }
+    }
   }
   return { type: 'nothing' } as const;
 }

--- a/src/game/items.test.ts
+++ b/src/game/items.test.ts
@@ -4,14 +4,18 @@ import { consumeItem } from './items';
 
 describe('items', () => {
   beforeEach(() => {
-    useGameStore.setState({ ...initialState, inventory: ['medkit'], player: { ...initialState.player, hp: 10 } });
+    useGameStore.setState({
+      ...initialState,
+      inventory: ['medkit_small'],
+      player: { ...initialState.player, hp: 10 },
+    });
   });
 
   it('medkit heals and is removed', () => {
-    const used = consumeItem('medkit');
+    const used = consumeItem('medkit_small');
     expect(used).toBe(true);
     const state = useGameStore.getState();
     expect(state.player.hp).toBe(50);
-    expect(state.inventory).not.toContain('medkit');
+    expect(state.inventory).not.toContain('medkit_small');
   });
 });

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -29,14 +29,7 @@ function applyItem(
 export function addItemToInventory(itemId: string) {
   const item = getItem(itemId);
   if (!item) return;
-  if (item.type === 'currency') {
-    useGameStore.setState((s) => ({
-      ...s,
-      player: { ...s.player, credits: s.player.credits + (item.value ?? 0) },
-    }));
-  } else {
-    useGameStore.setState((s) => ({ ...s, inventory: [...s.inventory, itemId] }));
-  }
+  useGameStore.setState((s) => ({ ...s, inventory: [...s.inventory, itemId] }));
 }
 
 export function equipItem(itemId: string) {
@@ -96,8 +89,8 @@ export function consumeItem(itemId: string): boolean {
     const inv = [...state.inventory];
     inv.splice(idx, 1);
     const newPlayer = { ...state.player };
-    if (item.effect?.hp) {
-      newPlayer.hp = Math.min(newPlayer.hp + item.effect.hp, newPlayer.hpMax);
+    if (item.effect?.heal) {
+      newPlayer.hp = Math.min(newPlayer.hp + item.effect.heal, newPlayer.hpMax);
     }
     used = true;
     return { ...state, inventory: inv, player: newPlayer };

--- a/src/ui/tabs/InventoryTab.tsx
+++ b/src/ui/tabs/InventoryTab.tsx
@@ -23,7 +23,7 @@ export default function InventoryTab() {
     if (!item) return;
     if (item.type === 'consumable') {
       const used = consumeItem(id);
-      if (used && id === 'medkit') {
+      if (used && id === 'medkit_small') {
         showToast('+50 HP (Medkit)');
       }
     } else {

--- a/src/ui/tabs/UpgradesTab.test.tsx
+++ b/src/ui/tabs/UpgradesTab.test.tsx
@@ -9,17 +9,17 @@ describe('Upgrades', () => {
     useGameStore.setState(initialState);
   });
 
-  it('buying hack_speed_1 reduces hack duration', () => {
+  it('buying neuro_patch_1 reduces hack duration', () => {
     vi.useFakeTimers();
-    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const rand = vi.spyOn(Math, 'random').mockReturnValue(0);
 
     useGameStore.setState((s) => ({
       ...s,
-      player: { ...s.player, credits: 100, data: 100 },
+      player: { ...s.player, credits: 200 },
     }));
 
     render(<UpgradesTab />);
-    fireEvent.click(screen.getByTestId('buy-hack_speed_1'));
+    fireEvent.click(screen.getByTestId('buy-neuro_patch_1'));
 
     render(<HackingTab />);
     fireEvent.click(screen.getByRole('button', { name: /start hack/i }));
@@ -27,35 +27,36 @@ describe('Upgrades', () => {
     act(() => {
       vi.advanceTimersByTime(9500);
     });
-    expect(useGameStore.getState().player.credits).toBe(50);
+    expect(useGameStore.getState().player.credits).toBe(80);
 
     act(() => {
       vi.advanceTimersByTime(100);
     });
-    expect(useGameStore.getState().player.credits).toBe(100);
+    expect(useGameStore.getState().player.credits).toBe(130);
 
+    rand.mockRestore();
     vi.useRealTimers();
   });
 
-  it('buying atk_1 increases atk by 1', () => {
+  it('buying muscle_fiber_1 increases atk by 1', () => {
     useGameStore.setState((s) => ({
       ...s,
-      player: { ...s.player, credits: 100 },
+      player: { ...s.player, credits: 200 },
     }));
 
     render(<UpgradesTab />);
-    fireEvent.click(screen.getByTestId('buy-atk_1'));
+    fireEvent.click(screen.getByTestId('buy-muscle_fiber_1'));
     expect(useGameStore.getState().player.atk).toBe(6);
   });
 
-  it('buying hp_1 increases hpMax by 10 and heals to full', () => {
+  it('buying dermal_plating_1 increases hpMax by 10 and heals to full', () => {
     useGameStore.setState((s) => ({
       ...s,
-      player: { ...s.player, credits: 100, hp: 10 },
+      player: { ...s.player, credits: 200, hp: 10 },
     }));
 
     render(<UpgradesTab />);
-    fireEvent.click(screen.getByTestId('buy-hp_1'));
+    fireEvent.click(screen.getByTestId('buy-dermal_plating_1'));
     const state = useGameStore.getState();
     expect(state.player.hpMax).toBe(60);
     expect(state.player.hp).toBe(60);

--- a/src/ui/tabs/UpgradesTab.tsx
+++ b/src/ui/tabs/UpgradesTab.tsx
@@ -1,20 +1,6 @@
-import upgradesData from '../../data/upgrades.json';
+import { upgrades, type Upgrade } from '../../data/upgrades';
 import { useGameStore } from '../../game/state/store';
 import { showToast } from '../Toast';
-
-interface Upgrade {
-  id: string;
-  name: string;
-  costCredits?: number;
-  costData?: number;
-  effects: {
-    hackingSpeed?: number;
-    atk?: number;
-    hpMax?: number;
-  };
-}
-
-const upgrades: Upgrade[] = upgradesData as Upgrade[];
 
 export default function UpgradesTab() {
   const player = useGameStore((s) => s.player);
@@ -23,7 +9,6 @@ export default function UpgradesTab() {
 
   const canAfford = (u: Upgrade) => {
     if (u.costCredits && player.credits < u.costCredits) return false;
-    if (u.costData && player.data < u.costData) return false;
     return true;
   };
 
@@ -33,7 +18,6 @@ export default function UpgradesTab() {
       if (!canAfford(u)) return state;
       const newPlayer = { ...state.player };
       if (u.costCredits) newPlayer.credits -= u.costCredits;
-      if (u.costData) newPlayer.data -= u.costData;
       if (u.effects.atk) newPlayer.atk += u.effects.atk;
       if (u.effects.hpMax) {
         newPlayer.hpMax += u.effects.hpMax;
@@ -70,7 +54,6 @@ export default function UpgradesTab() {
                 <div>{u.name}</div>
                 <div className="text-sm text-neon-cyan">
                   {u.costCredits ? `Credits: ${u.costCredits} ` : ''}
-                  {u.costData ? `Data: ${u.costData}` : ''}
                 </div>
               </div>
               <button


### PR DESCRIPTION
## Summary
- define typed items, upgrades, enemies, and locations data sets
- integrate new data with combat, exploration, inventory, and upgrades systems
- update tests for new data-driven gameplay

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68971ef1828c8331819f35f2a20f6006