### PR TITLE
Fix build by moving enemy lookup to data layer

### DIFF
--- a/src/data/enemies.ts
+++ b/src/data/enemies.ts
@@ -33,6 +33,5 @@ export const enemies: Enemy[] = [
   },
 ];
 
-export function getEnemy(id: string): Enemy | undefined {
-  return enemies.find((e) => e.id === id);
-}
+export const getEnemyById = (id: string): Enemy | undefined =>
+  enemies.find((e) => e.id === id);

--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -1,5 +1,5 @@
 import { useGameStore } from './state/store';
-import { getEnemy, type Enemy } from '../data/enemies';
+import { getEnemyById, type Enemy } from '../data/enemies';
 import { getItem } from '../data/items';
 
 export function calcDamage(atk: number, def: number): number {
@@ -12,7 +12,7 @@ function trimLog(log: string[]): string[] {
 }
 
 export function startCombat(enemyId: string) {
-  const enemy = getEnemy(enemyId);
+  const enemy = getEnemyById(enemyId);
   if (!enemy) return;
   useGameStore.setState((s) => ({
     ...s,
@@ -83,7 +83,7 @@ function handleDefeat(log: string[]) {
 export function attack() {
   const state = useGameStore.getState();
   if (!state.combat.inFight || !state.combat.enemyId) return;
-  const enemy = getEnemy(state.combat.enemyId);
+  const enemy = getEnemyById(state.combat.enemyId);
   if (!enemy) return;
   let enemyHp = state.combat.enemyHp;
   const log = [...state.combat.log];
@@ -116,7 +116,7 @@ export function attack() {
 export function flee() {
   const state = useGameStore.getState();
   if (!state.combat.inFight || !state.combat.enemyId) return;
-  const enemy = getEnemy(state.combat.enemyId);
+  const enemy = getEnemyById(state.combat.enemyId);
   if (!enemy) return;
   const log = [...state.combat.log];
   if (Math.random() < 0.75) {

--- a/src/test/enemies.test.ts
+++ b/src/test/enemies.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getEnemyById } from '../data/enemies';
+
+describe('getEnemyById', () => {
+  it('returns enemy with matching id', () => {
+    const enemy = getEnemyById('street_thug');
+    expect(enemy).toBeDefined();
+    expect(enemy?.id).toBe('street_thug');
+  });
+});

--- a/src/ui/tabs/CombatTab.tsx
+++ b/src/ui/tabs/CombatTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
-import { attack, flee, quickHeal, startCombat, getEnemy } from '../../game/combat';
-import { enemies } from '../../data/enemies';
+import { attack, flee, quickHeal, startCombat } from '../../game/combat';
+import { enemies, getEnemyById } from '../../data/enemies';
 import { useGameStore } from '../../game/state/store';
 
 export default function CombatTab() {
@@ -8,7 +8,7 @@ export default function CombatTab() {
   const player = useGameStore((s) => s.player);
   const [selected, setSelected] = useState(enemies[0]?.id ?? '');
 
-  const enemy = combat.enemyId ? getEnemy(combat.enemyId) : null;
+  const enemy = combat.enemyId ? getEnemyById(combat.enemyId) : null;
 
   return (
     <div className="space-y-4 p-4">


### PR DESCRIPTION
## Summary
- centralize enemy data access with `getEnemyById` helper in `data/enemies`
- update combat logic and UI to use new helper
- add unit test for `getEnemyById`

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68972231f97883319b914cda26499de2