### PR TITLE
feat: add consumable store and cyberware upgrades

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,12 +1,13 @@
 export type Item = {
   id: string;
   name: string;
-  description: string;
-  type: 'weapon' | 'armor' | 'consumable' | 'quest' | 'misc';
-  stats?: { attack?: number; defense?: number; heal?: number };
-  sellPrice?: number;
-  buyPrice?: number;
-  isPurchasable?: boolean; // true for store items, false for loot-only
+  type: 'consumable' | 'weapon' | 'armor' | 'accessory' | 'misc';
+  description?: string;
+  stats?: { attack?: number; defense?: number };
+  effect?: { heal?: number };
+  buyPriceCredits?: number;
+  source?: 'shop-only' | 'loot-only' | 'both';
+  iconText?: string;
 };
 
 export const items: Item[] = [
@@ -16,9 +17,9 @@ export const items: Item[] = [
     description: 'A simple blade that boosts attack.',
     type: 'weapon',
     stats: { attack: 5 },
-    sellPrice: 25,
-    buyPrice: 50,
-    isPurchasable: true,
+    buyPriceCredits: 50,
+    source: 'both',
+    iconText: '🗡️',
   },
   {
     id: 'leather_armor',
@@ -26,26 +27,36 @@ export const items: Item[] = [
     description: 'Light armor offering minimal protection.',
     type: 'armor',
     stats: { defense: 3 },
-    sellPrice: 20,
-    buyPrice: 40,
-    isPurchasable: true,
+    buyPriceCredits: 40,
+    source: 'both',
+    iconText: '🛡️',
   },
   {
-    id: 'medkit',
-    name: 'Medkit',
-    description: 'Restores 50 health when used.',
+    id: 'medkit_s',
+    name: 'Medkit (S)',
     type: 'consumable',
-    stats: { heal: 50 },
-    sellPrice: 10,
-    buyPrice: 20,
-    isPurchasable: true,
+    source: 'shop-only',
+    buyPriceCredits: 50,
+    effect: { heal: 50 },
+    iconText: '💊',
+    description: 'Restores 50 health when used.',
+  },
+  {
+    id: 'medkit_m',
+    name: 'Medkit (M)',
+    type: 'consumable',
+    source: 'shop-only',
+    buyPriceCredits: 120,
+    effect: { heal: 120 },
+    iconText: '💊',
+    description: 'Restores 120 health when used.',
   },
   {
     id: 'scrap_metal',
     name: 'Scrap Metal',
     description: 'Useful junk found in the slums.',
     type: 'misc',
-    isPurchasable: false,
+    source: 'loot-only',
   },
   {
     id: 'rare_blade',
@@ -53,13 +64,11 @@ export const items: Item[] = [
     description: 'An exceptionally crafted weapon.',
     type: 'weapon',
     stats: { attack: 15 },
-    sellPrice: 100,
-    buyPrice: 200,
-    isPurchasable: false,
+    buyPriceCredits: 200,
+    source: 'loot-only',
   },
 ];
 
 export function getItem(id: string): Item | undefined {
   return items.find((i) => i.id === id);
 }
-

--- a/src/data/lootTables.ts
+++ b/src/data/lootTables.ts
@@ -9,7 +9,6 @@ export const lootTables: LootTable[] = [
     locationId: 'slums',
     drops: [
       { itemId: 'scrap_metal', chance: 0.5 },
-      { itemId: 'medkit', chance: 0.05 },
     ],
   },
   {

--- a/src/data/upgrades.ts
+++ b/src/data/upgrades.ts
@@ -2,7 +2,7 @@ export interface Upgrade {
   id: string;
   name: string;
   costCredits: number;
-  effects: { atk?: number; hpMax?: number; hackingSpeed?: number };
+  effects: { hackingSpeed?: number; atk?: number; hpMax?: number };
   description?: string;
   iconText?: string;
 }
@@ -13,24 +13,21 @@ export const upgrades: Upgrade[] = [
     name: 'Neuro Patch I',
     costCredits: 120,
     effects: { hackingSpeed: 1.05 },
-    description: 'Boosts neural signal processing by 5%.',
     iconText: '🧠',
   },
   {
-    id: 'muscle_fiber_1',
-    name: 'Muscle Fiber Mesh',
-    costCredits: 100,
-    effects: { atk: 1 },
-    description: 'Synthetic fibers enhance strength.',
-    iconText: '💪',
+    id: 'tendo_servo_1',
+    name: 'Tendo-Servo I',
+    costCredits: 150,
+    effects: { atk: 2 },
+    iconText: '⚙️',
   },
   {
-    id: 'dermal_plating_1',
-    name: 'Dermal Plating I',
-    costCredits: 80,
-    effects: { hpMax: 10 },
-    description: 'Reinforced skin grafts improve survivability.',
-    iconText: '🛡',
+    id: 'subdermal_armor_1',
+    name: 'Subdermal Armor I',
+    costCredits: 130,
+    effects: { hpMax: 15 },
+    iconText: '🛡️',
   },
 ];
 

--- a/src/game/combat.test.ts
+++ b/src/game/combat.test.ts
@@ -30,7 +30,6 @@ describe('combat system', () => {
     expect(state.skills.combat.xp).toBe(10);
     expect(state.player.credits).toBe(5);
     expect(state.inventory.scrap_metal).toBe(1);
-    expect(state.inventory.medkit).toBe(1);
 
     rand.mockRestore();
   });

--- a/src/game/items.test.ts
+++ b/src/game/items.test.ts
@@ -1,21 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useGameStore, initialState } from './state/store';
-import { consumeItem } from './items';
+import { consume } from './shop';
 
 describe('items', () => {
   beforeEach(() => {
     useGameStore.setState({
       ...initialState,
-      inventory: { medkit: 1 },
+      inventory: { medkit_s: 1 },
       player: { ...initialState.player, hp: 10 },
     });
   });
 
   it('medkit heals and is removed', () => {
-    const used = consumeItem('medkit');
+    const used = consume('medkit_s');
     expect(used).toBe(true);
     const state = useGameStore.getState();
     expect(state.player.hp).toBe(50);
-    expect(state.inventory.medkit).toBeUndefined();
+    expect(state.inventory.medkit_s).toBeUndefined();
   });
 });

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -22,12 +22,11 @@ export function addItemToInventory(itemId: string, quantity = 1) {
 
 export function equipItem(itemId: string) {
   const item = getItem(itemId);
-  if (!item || item.type === 'consumable' || item.type === 'quest' || item.type === 'misc')
-    return;
+  if (!item || item.type === 'consumable' || item.type === 'misc') return;
   useGameStore.setState((state) => {
     const count = state.inventory[itemId] ?? 0;
     if (count <= 0) return state;
-    const slot = item.type as 'weapon' | 'armor';
+    const slot = item.type as 'weapon' | 'armor' | 'accessory';
     const newInventory = { ...state.inventory, [itemId]: count - 1 };
     if (newInventory[itemId] <= 0) delete newInventory[itemId];
     const newEquipped = { ...state.equipped };
@@ -61,24 +60,5 @@ export function unequipItem(slot: 'weapon' | 'armor' | 'accessory') {
     }
     return { ...state, inventory: newInventory, equipped: newEquipped, player };
   });
-}
-
-export function consumeItem(itemId: string): boolean {
-  const item = getItem(itemId);
-  if (!item || item.type !== 'consumable') return false;
-  let used = false;
-  useGameStore.setState((state) => {
-    const count = state.inventory[itemId] ?? 0;
-    if (count <= 0) return state;
-    const newInventory = { ...state.inventory, [itemId]: count - 1 };
-    if (newInventory[itemId] <= 0) delete newInventory[itemId];
-    const newPlayer = { ...state.player };
-    if (item.stats?.heal) {
-      newPlayer.hp = Math.min(newPlayer.hp + item.stats.heal, newPlayer.hpMax);
-    }
-    used = true;
-    return { ...state, inventory: newInventory, player: newPlayer };
-  });
-  return used;
 }
 

--- a/src/game/shop.test.ts
+++ b/src/game/shop.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useGameStore, initialState } from './state/store';
+import { buyConsumable, buyUpgrade } from './shop';
+
+describe('shop actions', () => {
+  beforeEach(() => {
+    useGameStore.setState(initialState);
+  });
+
+  it('buying consumable costs credits and adds to inventory', () => {
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, credits: 100 },
+    }));
+    const success = buyConsumable('medkit_s');
+    expect(success).toBe(true);
+    const state = useGameStore.getState();
+    expect(state.player.credits).toBe(50);
+    expect(state.inventory.medkit_s).toBe(1);
+  });
+
+  it('buying upgrade marks owned and updates stats', () => {
+    useGameStore.setState((s) => ({
+      ...s,
+      player: { ...s.player, credits: 200 },
+    }));
+    const success = buyUpgrade('tendo_servo_1');
+    expect(success).toBe(true);
+    const state = useGameStore.getState();
+    expect(state.player.credits).toBe(50);
+    expect(state.upgrades.owned.tendo_servo_1).toBe(true);
+    expect(state.player.atk).toBe(initialState.player.atk + 2);
+  });
+});

--- a/src/game/shop.ts
+++ b/src/game/shop.ts
@@ -1,0 +1,73 @@
+import { useGameStore } from './state/store';
+import { getItem } from '../data/items';
+import { getUpgrade } from '../data/upgrades';
+
+export function buyConsumable(itemId: string): boolean {
+  const item = getItem(itemId);
+  if (!item || item.type !== 'consumable') return false;
+  if (item.source === 'loot-only') return false;
+  const price = item.buyPriceCredits ?? 0;
+  let success = false;
+  useGameStore.setState((state) => {
+    if (state.player.credits < price) return state;
+    success = true;
+    return {
+      ...state,
+      player: { ...state.player, credits: state.player.credits - price },
+      inventory: {
+        ...state.inventory,
+        [itemId]: (state.inventory[itemId] ?? 0) + 1,
+      },
+    };
+  });
+  return success;
+}
+
+export function buyUpgrade(upgradeId: string): boolean {
+  const upgrade = getUpgrade(upgradeId);
+  if (!upgrade) return false;
+  let success = false;
+  useGameStore.setState((state) => {
+    if (state.upgrades.owned[upgradeId]) return state;
+    if (state.player.credits < upgrade.costCredits) return state;
+    success = true;
+    const owned = { ...state.upgrades.owned, [upgradeId]: true };
+    const player = { ...state.player, credits: state.player.credits - upgrade.costCredits };
+    if (upgrade.effects.atk) player.atk += upgrade.effects.atk;
+    if (upgrade.effects.hpMax) {
+      player.hpMax += upgrade.effects.hpMax;
+      player.hp = player.hpMax;
+    }
+    let timeMultiplier = 1;
+    for (const id of Object.keys(owned)) {
+      const u = getUpgrade(id);
+      if (u?.effects.hackingSpeed) timeMultiplier *= u.effects.hackingSpeed;
+    }
+    return {
+      ...state,
+      player,
+      hacking: { ...state.hacking, timeMultiplier },
+      upgrades: { owned },
+    };
+  });
+  return success;
+}
+
+export function consume(itemId: string): boolean {
+  const item = getItem(itemId);
+  if (!item || item.type !== 'consumable') return false;
+  let used = false;
+  useGameStore.setState((state) => {
+    const count = state.inventory[itemId] ?? 0;
+    if (count <= 0) return state;
+    used = true;
+    const newInventory = { ...state.inventory, [itemId]: count - 1 };
+    if (newInventory[itemId] <= 0) delete newInventory[itemId];
+    const player = { ...state.player };
+    if (item.effect?.heal) {
+      player.hp = Math.min(player.hp + item.effect.heal, player.hpMax);
+    }
+    return { ...state, inventory: newInventory, player };
+  });
+  return used;
+}

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -2,17 +2,19 @@ import { useState } from 'react';
 import HackingTab from './tabs/HackingTab';
 import CombatTab from './tabs/CombatTab';
 import InventoryTab from './tabs/InventoryTab';
+import StoreTab from './tabs/StoreTab';
 import UpgradesTab from './tabs/UpgradesTab';
 import SettingsMenu from './SettingsMenu';
 import { useGameStore } from '../game/state/store';
 import { NeonToast } from './Toast';
 
-type Tab = 'hacking' | 'combat' | 'inventory' | 'upgrades';
+type Tab = 'hacking' | 'combat' | 'inventory' | 'store' | 'upgrades';
 
 const tabs: { key: Tab; label: string }[] = [
   { key: 'hacking', label: 'Hacking' },
   { key: 'combat', label: 'Combat' },
   { key: 'inventory', label: 'Inventory' },
+  { key: 'store', label: 'Store' },
   { key: 'upgrades', label: 'Upgrades' }
 ];
 
@@ -26,6 +28,8 @@ export default function AppShell() {
         return <CombatTab />;
       case 'inventory':
         return <InventoryTab />;
+      case 'store':
+        return <StoreTab />;
       case 'upgrades':
         return <UpgradesTab />;
       default:

--- a/src/ui/tabs/InventoryTab.tsx
+++ b/src/ui/tabs/InventoryTab.tsx
@@ -1,5 +1,6 @@
 import { useGameStore } from '../../game/state/store';
-import { consumeItem, equipItem, unequipItem } from '../../game/items';
+import { equipItem, unequipItem } from '../../game/items';
+import { consume } from '../../game/shop';
 import { getItem } from '../../data/items';
 import { showToast } from '../Toast';
 
@@ -9,7 +10,7 @@ function ItemStats({ id }: { id: string }) {
   const stats = [] as string[];
   if (item.stats?.attack) stats.push(`ATK +${item.stats.attack}`);
   if (item.stats?.defense) stats.push(`DEF +${item.stats.defense}`);
-  if (item.stats?.heal) stats.push(`Heal ${item.stats.heal}`);
+  if (item.effect?.heal) stats.push(`Heal ${item.effect.heal}`);
   return <div className="text-sm text-neon-cyan">{stats.join(', ')}</div>;
 }
 
@@ -21,9 +22,9 @@ export default function InventoryTab() {
     const item = getItem(id);
     if (!item) return;
     if (item.type === 'consumable') {
-      const used = consumeItem(id);
-      if (used && id === 'medkit') {
-        showToast('+50 HP (Medkit)');
+      const used = consume(id);
+      if (used && item.effect?.heal) {
+        showToast(`+${item.effect.heal} HP (${item.name})`);
       }
     } else {
       equipItem(id);

--- a/src/ui/tabs/StoreTab.tsx
+++ b/src/ui/tabs/StoreTab.tsx
@@ -1,0 +1,50 @@
+import { items, getItem } from '../../data/items';
+import { useGameStore } from '../../game/state/store';
+import { buyConsumable } from '../../game/shop';
+import { showToast } from '../Toast';
+
+export default function StoreTab() {
+  const credits = useGameStore((s) => s.player.credits);
+  const consumables = items.filter(
+    (i) =>
+      i.type === 'consumable' &&
+      (i.source === 'shop-only' || i.source === 'both')
+  );
+
+  const buy = (id: string) => {
+    const item = getItem(id);
+    if (!item) return;
+    const success = buyConsumable(id);
+    if (success) {
+      showToast(`Purchased: ${item.name}`);
+    }
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <ul className="space-y-2">
+        {consumables.map((item) => (
+          <li key={item.id} className="flex items-center justify-between">
+            <div>
+              <div>
+                {item.iconText} {item.name}
+              </div>
+              {item.description && (
+                <div className="text-sm text-neon-cyan">{item.description}</div>
+              )}
+              <div className="text-sm text-neon-cyan">
+                Credits: {item.buyPriceCredits ?? 0}
+              </div>
+            </div>
+            <button
+              disabled={credits < (item.buyPriceCredits ?? 0)}
+              onClick={() => buy(item.id)}
+            >
+              Buy
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/ui/tabs/UpgradesTab.test.tsx
+++ b/src/ui/tabs/UpgradesTab.test.tsx
@@ -38,27 +38,27 @@ describe('Upgrades', () => {
     vi.useRealTimers();
   });
 
-  it('buying muscle_fiber_1 increases atk by 1', () => {
+  it('buying tendo_servo_1 increases atk by 2', () => {
     useGameStore.setState((s) => ({
       ...s,
       player: { ...s.player, credits: 200 },
     }));
 
     render(<UpgradesTab />);
-    fireEvent.click(screen.getByTestId('buy-muscle_fiber_1'));
-    expect(useGameStore.getState().player.atk).toBe(6);
+    fireEvent.click(screen.getByTestId('buy-tendo_servo_1'));
+    expect(useGameStore.getState().player.atk).toBe(7);
   });
 
-  it('buying dermal_plating_1 increases hpMax by 10 and heals to full', () => {
+  it('buying subdermal_armor_1 increases hpMax by 15 and heals to full', () => {
     useGameStore.setState((s) => ({
       ...s,
       player: { ...s.player, credits: 200, hp: 10 },
     }));
 
     render(<UpgradesTab />);
-    fireEvent.click(screen.getByTestId('buy-dermal_plating_1'));
+    fireEvent.click(screen.getByTestId('buy-subdermal_armor_1'));
     const state = useGameStore.getState();
-    expect(state.player.hpMax).toBe(60);
-    expect(state.player.hp).toBe(60);
+    expect(state.player.hpMax).toBe(65);
+    expect(state.player.hp).toBe(65);
   });
 });

--- a/src/ui/tabs/UpgradesTab.tsx
+++ b/src/ui/tabs/UpgradesTab.tsx
@@ -1,42 +1,26 @@
-import { upgrades, type Upgrade } from '../../data/upgrades';
+import { upgrades } from '../../data/upgrades';
 import { useGameStore } from '../../game/state/store';
+import { buyUpgrade } from '../../game/shop';
 import { showToast } from '../Toast';
 
 export default function UpgradesTab() {
   const player = useGameStore((s) => s.player);
   const owned = useGameStore((s) => s.upgrades.owned);
-  const setState = useGameStore.setState;
 
-  const canAfford = (u: Upgrade) => {
-    if (u.costCredits && player.credits < u.costCredits) return false;
-    return true;
+  const canAfford = (cost: number) => player.credits >= cost;
+
+  const buy = (id: string, name: string) => {
+    const success = buyUpgrade(id);
+    if (success) showToast(`Installed: ${name}`);
   };
 
-  const buy = (u: Upgrade) => {
-    setState((state) => {
-      if (state.upgrades.owned[u.id]) return state;
-      if (!canAfford(u)) return state;
-      const newPlayer = { ...state.player };
-      if (u.costCredits) newPlayer.credits -= u.costCredits;
-      if (u.effects.atk) newPlayer.atk += u.effects.atk;
-      if (u.effects.hpMax) {
-        newPlayer.hpMax += u.effects.hpMax;
-        newPlayer.hp = newPlayer.hpMax;
-      }
-      const newHacking = { ...state.hacking };
-      if (u.effects.hackingSpeed) {
-        newHacking.timeMultiplier *= u.effects.hackingSpeed;
-      }
-      return {
-        ...state,
-        player: newPlayer,
-        hacking: newHacking,
-        upgrades: {
-          owned: { ...state.upgrades.owned, [u.id]: true },
-        },
-      };
-    });
-    showToast(`Purchased: ${u.name}`);
+  const effectSummary = (u: typeof upgrades[number]) => {
+    const parts: string[] = [];
+    if (u.effects.hackingSpeed)
+      parts.push(`Hack x${u.effects.hackingSpeed.toFixed(2)}`);
+    if (u.effects.atk) parts.push(`ATK +${u.effects.atk}`);
+    if (u.effects.hpMax) parts.push(`HP +${u.effects.hpMax}`);
+    return parts.join(', ');
   };
 
   return (
@@ -47,18 +31,21 @@ export default function UpgradesTab() {
       <ul className="space-y-2">
         {upgrades.map((u) => {
           const isOwned = owned[u.id];
-          const disabled = isOwned || !canAfford(u);
+          const disabled = isOwned || !canAfford(u.costCredits);
           return (
             <li key={u.id} className="flex items-center justify-between">
               <div>
-                <div>{u.name}</div>
+                <div>
+                  {u.iconText} {u.name}
+                </div>
+                <div className="text-sm text-neon-cyan">{effectSummary(u)}</div>
                 <div className="text-sm text-neon-cyan">
-                  {u.costCredits ? `Credits: ${u.costCredits} ` : ''}
+                  Credits: {u.costCredits}
                 </div>
               </div>
               <button
                 data-testid={`buy-${u.id}`}
-                onClick={() => buy(u)}
+                onClick={() => buy(u.id, u.name)}
                 disabled={disabled}
               >
                 {isOwned ? 'Owned' : 'Buy'}


### PR DESCRIPTION
## Summary
- define item and upgrade data including shop-only medkits and three cyberware upgrades
- add game actions to buy consumables, install upgrades, and consume items with stat recalculation
- introduce Store and updated Upgrades UI tabs to purchase consumables and cyberware

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_689728993a508331a00af243ed28e2ca