### PR TITLE
Fix hacking loot item definitions and inventory guard

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -3,10 +3,11 @@ export type Item = {
   name: string;
   type: 'consumable' | 'weapon' | 'armor' | 'accessory' | 'misc';
   description?: string;
-  stats?: { attack?: number; defense?: number };
+  stats?: { attack?: number; defense?: number; hackingSpeed?: number };
   effect?: { heal?: number };
   buyPriceCredits?: number;
   source?: 'shop-only' | 'loot-only' | 'both';
+  rarity?: 'common' | 'uncommon' | 'rare';
   iconText?: string;
 };
 
@@ -66,6 +67,24 @@ export const items: Item[] = [
     stats: { attack: 15 },
     buyPriceCredits: 200,
     source: 'loot-only',
+  },
+  {
+    id: 'neural_chip',
+    name: 'Neural Chip',
+    type: 'accessory',
+    source: 'loot-only',
+    stats: { hackingSpeed: 1.05 },
+    rarity: 'rare',
+    iconText: '🔩',
+  },
+  {
+    id: 'shock_baton',
+    name: 'Shock Baton',
+    type: 'weapon',
+    source: 'loot-only',
+    stats: { attack: 3 },
+    rarity: 'uncommon',
+    iconText: '🗡',
   },
 ];
 

--- a/src/game/hacking.ts
+++ b/src/game/hacking.ts
@@ -32,17 +32,12 @@ export function performHack(state: GameState): {
     level += 1;
   }
 
-  const inv = { ...state.inventory };
   const drop = rollHackingLoot();
-  if (drop) {
-    inv[drop] = (inv[drop] ?? 0) + 1;
-  }
 
   const newState: GameState = {
     ...state,
     resources: { ...state.resources, credits: state.resources.credits + credits },
     skills: { ...state.skills, hacking: { level, xp } },
-    inventory: inv,
   };
 
   return { state: newState, rewards: { credits, data: dataGain, xp: xpGain }, loot: drop };

--- a/src/game/items.test.ts
+++ b/src/game/items.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useGameStore, initialState } from './state/store';
 import { consume } from './shop';
+import { addItemToInventory } from './items';
 
 describe('items', () => {
   beforeEach(() => {
@@ -17,5 +18,14 @@ describe('items', () => {
     const state = useGameStore.getState();
     expect(state.player.hp).toBe(50);
     expect(state.inventory.medkit_s).toBeUndefined();
+  });
+
+  it('skips and warns on unknown item', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    addItemToInventory('unknown_item');
+    const state = useGameStore.getState();
+    expect(state.inventory.unknown_item).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -10,7 +10,10 @@ function applyItem(player: GameState['player'], item: Item, op: 1 | -1) {
 
 export function addItemToInventory(itemId: string, quantity = 1) {
   const item = getItem(itemId);
-  if (!item) return;
+  if (!item) {
+    console.warn(`Unknown item '${itemId}' - not added to inventory`);
+    return;
+  }
   useGameStore.setState((s) => ({
     ...s,
     inventory: {

--- a/src/game/offline.ts
+++ b/src/game/offline.ts
@@ -1,5 +1,6 @@
 import { GameState } from './state/store';
 import { BASE_HACK_DURATION, performHack } from './hacking';
+import { getItem } from '../data/items';
 
 export const MAX_OFFLINE_MS = 12 * 60 * 60 * 1000;
 
@@ -30,6 +31,19 @@ export function applyOfflineProgress(
     for (let i = 0; i < ticks; i++) {
       const result = performHack(newState);
       newState = result.state;
+      if (result.loot) {
+        if (getItem(result.loot)) {
+          newState = {
+            ...newState,
+            inventory: {
+              ...newState.inventory,
+              [result.loot]: (newState.inventory[result.loot] ?? 0) + 1,
+            },
+          };
+        } else {
+          console.warn(`Unknown item '${result.loot}' - not added to inventory`);
+        }
+      }
       rewards.credits += result.rewards.credits;
       rewards.data += result.rewards.data;
       rewards.xp += result.rewards.xp;

--- a/src/ui/tabs/HackingTab.test.tsx
+++ b/src/ui/tabs/HackingTab.test.tsx
@@ -8,7 +8,7 @@ describe('HackingTab', () => {
     useGameStore.setState(initialState); // reset store
   });
 
-  it('rewards credits and xp after hacking completes', () => {
+  it('rewards credits, xp and loot after hacking completes', () => {
     vi.useFakeTimers();
     vi.spyOn(Math, 'random').mockReturnValue(0); // deterministic rewards
 
@@ -22,6 +22,7 @@ describe('HackingTab', () => {
     const state = useGameStore.getState();
     expect(state.resources.credits).toBe(50);
     expect(state.skills.hacking.xp).toBe(5);
+    expect(state.inventory.neural_chip).toBe(1);
 
     vi.useRealTimers();
   });

--- a/src/ui/tabs/HackingTab.tsx
+++ b/src/ui/tabs/HackingTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useGameStore } from '../../game/state/store';
 import { BASE_HACK_DURATION, performHack } from '../../game/hacking';
+import { addItemToInventory } from '../../game/items';
 import { getNextLevelXp } from '../../game/skills';
 
 export default function HackingTab() {
@@ -24,10 +25,13 @@ export default function HackingTab() {
       if (elapsed >= duration) {
         clearInterval(interval);
 
+        let loot: string | null = null;
         setState((state) => {
-          const { state: updated } = performHack(state);
+          const { state: updated, loot: drop } = performHack(state);
+          loot = drop ?? null;
           return { ...updated, hacking: { ...updated.hacking, inProgress: false } };
         });
+        if (loot) addItemToInventory(loot);
 
         setInProgress(false);
         setProgress(0);


### PR DESCRIPTION
## Summary
- define Neural Chip and Shock Baton items used by hacking loot tables
- wire hacking rewards to add items via inventory helper
- skip and warn when adding unknown items to inventory

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68973578179883319bbd4db63e82295f