### PR TITLE
feat: add exploration tab

### DIFF
--- a/src/data/locations.ts
+++ b/src/data/locations.ts
@@ -3,6 +3,7 @@ export interface Location {
   name: string;
   enemies: string[]; // enemy IDs
   description?: string;
+  encounterRates?: { loot: number };
 }
 
 export const locations: Location[] = [

--- a/src/game/exploration.test.ts
+++ b/src/game/exploration.test.ts
@@ -9,7 +9,7 @@ describe('exploration', () => {
   });
 
   it('triggers enemy encounter', () => {
-    const rand = vi.spyOn(Math, 'random').mockReturnValue(0);
+    const rand = vi.spyOn(Math, 'random').mockReturnValue(0.5);
     const result = explore();
     const state = useGameStore.getState();
     expect(result?.type).toBe('enemy');
@@ -21,13 +21,15 @@ describe('exploration', () => {
     setLocation('slums');
     const rand = vi
       .spyOn(Math, 'random')
-      .mockReturnValueOnce(0.99) // enemy roll -> loot path
+      .mockReturnValueOnce(0) // encounter roll -> loot path
       .mockReturnValueOnce(0) // scrap metal success
       .mockReturnValue(1); // fail remaining drops
     const result = explore();
     expect(result?.type).toBe('loot');
+    expect(result?.itemId).toBe('scrap_metal');
+    expect(result?.quantity).toBe(1);
     const state = useGameStore.getState();
-    expect(state.inventory.scrap_metal).toBe(1);
+    expect(state.inventory.scrap_metal).toBeUndefined();
     rand.mockRestore();
   });
 });

--- a/src/game/exploration.ts
+++ b/src/game/exploration.ts
@@ -1,7 +1,6 @@
 import { useGameStore } from './state/store';
 import { getLocation } from '../data/locations';
 import { startCombat } from './combat';
-import { addItemToInventory } from './items';
 import { rollLoot } from '../data/lootTables';
 
 export function setLocation(locationId: string) {
@@ -13,17 +12,17 @@ export function explore() {
   if (!state.location) return null;
   const loc = getLocation(state.location);
   if (!loc) return null;
+  const lootChance = loc.encounterRates?.loot ?? 0.01;
   const roll = Math.random();
-  if (loc.enemies.length && roll < 0.8) {
+  if (roll >= lootChance && loc.enemies.length) {
     const enemyId = loc.enemies[Math.floor(Math.random() * loc.enemies.length)];
-    startCombat(enemyId);
+    startCombat(enemyId, { fromExploration: true });
     return { type: 'enemy', enemyId } as const;
   }
   const loot = rollLoot(loc.id);
   if (loot.items.length > 0) {
     const drop = loot.items[0];
-    addItemToInventory(drop.itemId, drop.quantity);
-    return { type: 'loot', itemId: drop.itemId } as const;
+    return { type: 'loot', itemId: drop.itemId, quantity: drop.quantity } as const;
   }
   if (loot.credits > 0) {
     useGameStore.setState((s) => ({

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -26,7 +26,9 @@ export interface GameState {
     enemyHp: number;
     inFight: boolean;
     log: string[];
+    fromExploration: boolean;
   };
+  explorationLog: string[];
   meta: { lastSaveTimestamp: number | null };
 }
 
@@ -47,7 +49,8 @@ export const initialState: GameState = {
   inventory: {},
   equipped: { weapon: null, armor: null, accessory: null },
   location: null,
-  combat: { enemyId: null, enemyHp: 0, inFight: false, log: [] },
+  combat: { enemyId: null, enemyHp: 0, inFight: false, log: [], fromExploration: false },
+  explorationLog: [],
   meta: { lastSaveTimestamp: null },
 };
 

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -8,6 +8,7 @@ describe('AppShell', () => {
     expect(screen.getByText('Hacking L1')).toBeInTheDocument();
     expect(screen.getByText('Combat L1')).toBeInTheDocument();
     expect(screen.getByTestId('tab-content')).toHaveTextContent('Start hack');
+    expect(screen.getByRole('button', { name: 'Exploration' })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Combat' }));
     expect(screen.getByRole('button', { name: 'Engage' })).toBeInTheDocument();
   });

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import HackingTab from './tabs/HackingTab';
 import CombatTab from './tabs/CombatTab';
+import ExplorationTab from './tabs/ExplorationTab';
 import InventoryTab from './tabs/InventoryTab';
 import StoreTab from './tabs/StoreTab';
 import UpgradesTab from './tabs/UpgradesTab';
@@ -9,11 +10,19 @@ import SettingsMenu from './SettingsMenu';
 import { useGameStore } from '../game/state/store';
 import { NeonToast } from './Toast';
 
-type Tab = 'hacking' | 'combat' | 'inventory' | 'store' | 'upgrades' | 'character';
+export type Tab =
+  | 'hacking'
+  | 'combat'
+  | 'inventory'
+  | 'store'
+  | 'upgrades'
+  | 'character'
+  | 'exploration';
 
 const tabs: { key: Tab; label: string }[] = [
   { key: 'character', label: 'Character' },
   { key: 'hacking', label: 'Hacking' },
+  { key: 'exploration', label: 'Exploration' },
   { key: 'combat', label: 'Combat' },
   { key: 'inventory', label: 'Inventory' },
   { key: 'store', label: 'Store' },
@@ -30,7 +39,9 @@ export default function AppShell() {
       case 'character':
         return <CharacterTab />;
       case 'combat':
-        return <CombatTab />;
+        return <CombatTab onNavigate={setCurrent} />;
+      case 'exploration':
+        return <ExplorationTab onNavigate={setCurrent} />;
       case 'inventory':
         return <InventoryTab />;
       case 'store':

--- a/src/ui/tabs/CombatTab.tsx
+++ b/src/ui/tabs/CombatTab.tsx
@@ -2,8 +2,13 @@ import { useState } from 'react';
 import { attack, flee, quickHeal, startCombat } from '../../game/combat';
 import { enemies, getEnemyById } from '../../data/enemies';
 import { useGameStore } from '../../game/state/store';
+import type { Tab } from '../AppShell';
 
-export default function CombatTab() {
+interface Props {
+  onNavigate?: (tab: Tab) => void;
+}
+
+export default function CombatTab({ onNavigate }: Props) {
   const combat = useGameStore((s) => s.combat);
   const player = useGameStore((s) => s.player);
   const [selected, setSelected] = useState(enemies[0]?.id ?? '');
@@ -31,6 +36,19 @@ export default function CombatTab() {
             Engage
           </button>
           <button onClick={quickHeal}>Quick Heal</button>
+          {combat.fromExploration && (
+            <button
+              onClick={() => {
+                useGameStore.setState((s) => ({
+                  ...s,
+                  combat: { ...s.combat, fromExploration: false },
+                }));
+                onNavigate?.('exploration');
+              }}
+            >
+              Continue Exploring
+            </button>
+          )}
         </div>
       ) : (
         <div className="space-y-4">

--- a/src/ui/tabs/ExplorationTab.tsx
+++ b/src/ui/tabs/ExplorationTab.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import type { Tab } from '../AppShell';
+import { locations } from '../../data/locations';
+import { getEnemyById } from '../../data/enemies';
+import { getItem } from '../../data/items';
+import { setLocation, explore } from '../../game/exploration';
+import { addItemToInventory } from '../../game/items';
+import { useGameStore } from '../../game/state/store';
+
+interface Props {
+  onNavigate: (tab: Tab) => void;
+}
+
+export default function ExplorationTab({ onNavigate }: Props) {
+  const currentLocation = useGameStore((s) => s.location);
+  const log = useGameStore((s) => s.explorationLog);
+  const [loot, setLoot] = useState<{ itemId: string; quantity: number } | null>(null);
+
+  const appendLog = (entry: string) => {
+    useGameStore.setState((s) => ({
+      ...s,
+      explorationLog: [...s.explorationLog, entry].slice(-5),
+    }));
+  };
+
+  const handleExplore = () => {
+    const result = explore();
+    if (!result) return;
+    if (result.type === 'enemy') {
+      const enemy = getEnemyById(result.enemyId);
+      appendLog(`Encountered ${enemy?.name ?? result.enemyId}`);
+      onNavigate('combat');
+    } else if (result.type === 'loot') {
+      setLoot({ itemId: result.itemId, quantity: result.quantity });
+    } else if (result.type === 'credits') {
+      appendLog(`Found ${result.amount} credits`);
+    } else {
+      appendLog('Found nothing');
+    }
+  };
+
+  const confirmLoot = () => {
+    if (!loot) return;
+    addItemToInventory(loot.itemId, loot.quantity);
+    const item = getItem(loot.itemId);
+    appendLog(
+      `Found ${loot.quantity > 1 ? `${loot.quantity}x ` : ''}${item?.name ?? loot.itemId}`,
+    );
+    setLoot(null);
+  };
+
+  return (
+    <div className="space-y-4 p-4">
+      <div>
+        <select
+          value={currentLocation ?? ''}
+          onChange={(e) => setLocation(e.target.value)}
+          className="bg-black"
+        >
+          <option value="">Select Location</option>
+          {locations.map((l) => (
+            <option key={l.id} value={l.id}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <button onClick={handleExplore} disabled={!currentLocation}>
+        Explore
+      </button>
+      <div className="space-y-1">
+        {log.map((l, i) => (
+          <div key={i}>{l}</div>
+        ))}
+      </div>
+      {loot && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black/70">
+          <div className="space-y-4 bg-background p-4 text-center">
+            <div>You found {getItem(loot.itemId)?.name ?? loot.itemId}!</div>
+            <button onClick={confirmLoot}>Continue</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Exploration tab for location-based encounters
- show loot modal and log exploration events
- allow returning to exploration after combat

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689737384cb083318238f84a237f0fbc