### PR TITLE
refactor: centralize loot handling

### DIFF
--- a/src/game/hacking.ts
+++ b/src/game/hacking.ts
@@ -1,5 +1,6 @@
 import { GameState } from './state/store';
 import { gainSkillXpState } from './skills';
+import { grantLoot, rollLoot, type LootEntry } from './loot';
 
 export const BASE_HACK_DURATION = 10000; // ms
 
@@ -9,12 +10,10 @@ export interface HackRewards {
   xp: number;
 }
 
-function rollHackingLoot(): string | null {
-  const roll = Math.random();
-  if (roll < 0.01) return 'neural_chip';
-  if (roll < 0.03) return 'shock_baton';
-  return null;
-}
+const HACK_LOOT_TABLE: LootEntry[] = [
+  { itemId: 'neural_chip', chance: 0.01 },
+  { itemId: 'shock_baton', chance: 0.03 },
+];
 
 export function performHack(state: GameState): {
   state: GameState;
@@ -31,12 +30,13 @@ export function performHack(state: GameState): {
   };
   const xpResult = gainSkillXpState(newState, 'hacking', xpGain);
   newState = xpResult.state;
-  const drop = rollHackingLoot();
+  const drops = rollLoot(HACK_LOOT_TABLE);
+  grantLoot(drops);
 
   return {
     state: newState,
     rewards: { credits, data: dataGain, xp: xpGain },
-    loot: drop,
+    loot: drops[0] ?? null,
     playerLeveled: xpResult.playerLeveled,
   };
 }

--- a/src/game/loot.ts
+++ b/src/game/loot.ts
@@ -1,0 +1,44 @@
+export type LootEntry = {
+  itemId: string;
+  chance: number;
+  min?: number;
+  max?: number;
+};
+
+export type CreditsDrop = { min: number; max: number };
+
+import { addItemToInventory } from './items';
+import { getItem } from '../data/items';
+
+export function rollLoot(table: LootEntry[], rng: () => number = Math.random): string[] {
+  const results: string[] = [];
+  for (const drop of table) {
+    if (rng() < drop.chance) {
+      const qty =
+        drop.min !== undefined && drop.max !== undefined
+          ? Math.floor(rng() * (drop.max - drop.min + 1)) + drop.min
+          : drop.min ?? 1;
+      for (let i = 0; i < qty; i++) {
+        results.push(drop.itemId);
+      }
+    }
+  }
+  return results;
+}
+
+export function rollCredits(drop?: CreditsDrop, rng: () => number = Math.random): number {
+  if (!drop) return 0;
+  const { min, max } = drop;
+  return Math.floor(rng() * (max - min + 1)) + min;
+}
+
+export function grantLoot(itemIds: string[]) {
+  for (const id of itemIds) {
+    const item = getItem(id);
+    if (!item) {
+      console.warn(`Unknown itemId: ${id}`);
+      continue;
+    }
+    addItemToInventory(id, 1);
+  }
+}


### PR DESCRIPTION
## Summary
- add shared loot helpers to roll drops, credits and grant items
- refactor combat, exploration and hacking to use centralized loot logic

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68975fde4f788331b21d7233ed7b978c