### PR TITLE
Require consumables for healing in combat

### DIFF
--- a/src/game/combat.ts
+++ b/src/game/combat.ts
@@ -209,9 +209,3 @@ export function flee() {
   }));
 }
 
-export function quickHeal() {
-  useGameStore.setState((s) => ({
-    ...s,
-    player: { ...s.player, hp: s.player.hpMax },
-  }));
-}

--- a/src/game/items.test.ts
+++ b/src/game/items.test.ts
@@ -20,6 +20,18 @@ describe('items', () => {
     expect(state.inventory.medkit_s).toBeUndefined();
   });
 
+  it('cannot heal without consumable', () => {
+    useGameStore.setState({
+      ...initialState,
+      inventory: {},
+      player: { ...initialState.player, hp: 10 },
+    });
+    const used = consume('medkit_s');
+    expect(used).toBe(false);
+    const state = useGameStore.getState();
+    expect(state.player.hp).toBe(10);
+  });
+
   it('skips and warns on unknown item', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     addItemToInventory('unknown_item');

--- a/src/ui/components/CombatPanel.tsx
+++ b/src/ui/components/CombatPanel.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
 import { getEnemyById } from '../../data/enemies';
 import { getItem } from '../../data/items';
-import { attack, flee, quickHeal } from '../../game/combat';
+import { attack, flee } from '../../game/combat';
+import { consume } from '../../game/shop';
 import { useGameStore } from '../../game/state/store';
+import { showToast } from '../Toast';
 import ButtonNeon from './ButtonNeon';
 import ProgressBarNeon from './ProgressBarNeon';
 
@@ -9,9 +12,32 @@ export default function CombatPanel() {
   const combat = useGameStore((s) => s.combat);
   const player = useGameStore((s) => s.player);
   const equipped = useGameStore((s) => s.equipped);
+  const inventory = useGameStore((s) => s.inventory);
+  const [showItems, setShowItems] = useState(false);
+
   const enemy = combat.enemyId ? getEnemyById(combat.enemyId) : null;
-  const weapon = equipped.weapon ? getItem(equipped.weapon)?.name ?? equipped.weapon : 'None';
-  const armor = equipped.armor ? getItem(equipped.armor)?.name ?? equipped.armor : 'None';
+  const weapon =
+    equipped.weapon ? getItem(equipped.weapon)?.name ?? equipped.weapon : 'None';
+  const armor =
+    equipped.armor ? getItem(equipped.armor)?.name ?? equipped.armor : 'None';
+
+  const healingItems = Object.entries(inventory)
+    .filter(([id, qty]) => qty > 0 && getItem(id)?.effect?.heal)
+    .map(([id, qty]) => ({ id, qty, item: getItem(id)! }));
+
+  const handleUseItem = (id: string) => {
+    const before = useGameStore.getState().player.hp;
+    const used = consume(id);
+    if (used) {
+      const after = useGameStore.getState().player.hp;
+      const healed = after - before;
+      const item = getItem(id);
+      if (item?.effect?.heal) {
+        showToast(`+${healed} HP (${item.name})`);
+      }
+    }
+    setShowItems(false);
+  };
 
   return (
     <div className="space-y-4">
@@ -41,10 +67,35 @@ export default function CombatPanel() {
           <div key={i}>{l}</div>
         ))}
       </div>
-      <div className="flex justify-center gap-2 border-t pt-2">
-        <ButtonNeon onClick={attack}>Attack</ButtonNeon>
-        <ButtonNeon onClick={quickHeal}>Use Item</ButtonNeon>
-        <ButtonNeon onClick={flee}>Flee</ButtonNeon>
+      <div className="flex flex-col items-center gap-2 border-t pt-2">
+        <div className="flex justify-center gap-2">
+          <ButtonNeon onClick={attack}>Attack</ButtonNeon>
+          <ButtonNeon
+            onClick={() => setShowItems((v) => !v)}
+            disabled={healingItems.length === 0}
+            title={healingItems.length === 0 ? 'No healing items available' : undefined}
+          >
+            Use Item
+          </ButtonNeon>
+          <ButtonNeon onClick={flee}>Flee</ButtonNeon>
+        </div>
+        {showItems && healingItems.length > 0 && (
+          <div className="flex flex-wrap justify-center gap-2">
+            {healingItems.map(({ id, qty, item }) => (
+              <ButtonNeon
+                key={id}
+                onClick={() => handleUseItem(id)}
+                className="px-2"
+              >
+                {item.name}
+                {qty > 1 && ` x${qty}`}
+              </ButtonNeon>
+            ))}
+          </div>
+        )}
+        {healingItems.length === 0 && (
+          <div className="text-sm text-neon-magenta">No healing items</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace free Quick Heal with Use Item menu in combat
- Consume healing items to restore HP with toast feedback
- Remove quickHeal function and cover item-based healing in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689762f8e2e483318f6cdc8c6035aafb