### PR TITLE
feat: add item descriptions, selling, and store categories

### DIFF
--- a/src/data/items.ts
+++ b/src/data/items.ts
@@ -1,93 +1,106 @@
 import type { Stats, Effect } from '../types/stats';
 
+export type ItemType = 'weapon' | 'armor' | 'consumable' | 'upgrade' | 'misc';
+
 export type Item = {
   id: string;
   name: string;
-  type: 'consumable' | 'weapon' | 'armor' | 'accessory' | 'misc';
-  description?: string;
+  type: ItemType;
+  description: string;
+  value: number;
   stats?: Stats;
   effect?: Effect;
-  buyPriceCredits?: number;
-  buyPriceData?: number;
   source?: 'shop-only' | 'loot-only' | 'both';
-  rarity?: 'common' | 'uncommon' | 'rare';
-  iconText?: string;
+  rarity?: 'common' | 'rare' | 'epic' | 'legendary';
+};
+
+export const ITEM_TYPE_ICONS: Record<ItemType, string> = {
+  weapon: '🗡️',
+  armor: '🛡️',
+  consumable: '💊',
+  upgrade: '⚙️',
+  misc: '📦',
 };
 
 export const items: Item[] = [
   {
     id: 'basic_sword',
     name: 'Basic Sword',
-    description: 'A simple blade that boosts attack.',
     type: 'weapon',
+    description: 'A simple blade that boosts attack.',
+    value: 50,
     stats: { atk: 5 },
-    buyPriceCredits: 50,
     source: 'both',
-    iconText: '🗡️',
+    rarity: 'common',
   },
   {
     id: 'leather_armor',
     name: 'Leather Armor',
-    description: 'Light armor offering minimal protection.',
     type: 'armor',
+    description: 'Light armor offering minimal protection.',
+    value: 40,
     stats: { def: 3 },
-    buyPriceCredits: 40,
     source: 'both',
-    iconText: '🛡️',
+    rarity: 'common',
   },
   {
     id: 'medkit_s',
     name: 'Medkit (S)',
     type: 'consumable',
-    source: 'shop-only',
-    buyPriceCredits: 50,
-    effect: { heal: 50 },
-    iconText: '💊',
     description: 'Restores 50 health when used.',
+    value: 50,
+    effect: { heal: 50 },
+    source: 'shop-only',
+    rarity: 'common',
   },
   {
     id: 'medkit_m',
     name: 'Medkit (M)',
     type: 'consumable',
-    source: 'shop-only',
-    buyPriceData: 25,
-    effect: { heal: 120 },
-    iconText: '💊',
     description: 'Restores 120 health when used.',
+    value: 100,
+    effect: { heal: 120 },
+    source: 'shop-only',
+    rarity: 'common',
   },
   {
     id: 'scrap_metal',
     name: 'Scrap Metal',
-    description: 'Useful junk found in the slums.',
     type: 'misc',
+    description: 'Useful junk found in the slums.',
+    value: 5,
     source: 'loot-only',
+    rarity: 'common',
   },
   {
     id: 'rare_blade',
     name: 'Rare Blade',
-    description: 'An exceptionally crafted weapon.',
     type: 'weapon',
+    description: 'An exceptionally crafted weapon.',
+    value: 200,
     stats: { atk: 15 },
-    buyPriceCredits: 200,
     source: 'loot-only',
+    rarity: 'epic',
   },
   {
     id: 'neural_chip',
     name: 'Neural Chip',
-    type: 'accessory',
-    source: 'loot-only',
+    type: 'upgrade',
+    description: 'Enhances neural processing speed.',
+    value: 150,
     stats: { hackingSpeed: 1.05 },
+    source: 'loot-only',
     rarity: 'rare',
-    iconText: '🔩',
   },
   {
     id: 'shock_baton',
     name: 'Shock Baton',
     type: 'weapon',
-    source: 'loot-only',
+    description: 'Stuns enemies with an electric charge.',
+    value: 120,
     stats: { atk: 3 },
-    rarity: 'uncommon',
-    iconText: '🗡',
+    source: 'loot-only',
+    rarity: 'rare',
   },
 ];
 

--- a/src/game/items.ts
+++ b/src/game/items.ts
@@ -54,7 +54,10 @@ export function equipItem(itemId: string) {
   useGameStore.setState((state) => {
     const count = state.inventory[itemId] ?? 0;
     if (count <= 0) return state;
-    const slot = item.type as 'weapon' | 'armor' | 'accessory';
+    const slot =
+      item.type === 'upgrade'
+        ? 'accessory'
+        : (item.type as 'weapon' | 'armor' | 'accessory');
     const newInventory = { ...state.inventory, [itemId]: count - 1 };
     if (newInventory[itemId] <= 0) delete newInventory[itemId];
     const newEquipped = { ...state.equipped };
@@ -102,5 +105,28 @@ export function unequipItem(slot: 'weapon' | 'armor' | 'accessory') {
       bonuses,
     };
   });
+}
+
+export function sellItem(itemId: string): boolean {
+  const item = getItem(itemId);
+  if (!item) return false;
+  let sold = false;
+  useGameStore.setState((state) => {
+    const count = state.inventory[itemId] ?? 0;
+    const isEquipped = Object.values(state.equipped).includes(itemId);
+    if (count <= 0 || isEquipped) return state;
+    sold = true;
+    const newInventory = { ...state.inventory, [itemId]: count - 1 };
+    if (newInventory[itemId] <= 0) delete newInventory[itemId];
+    return {
+      ...state,
+      inventory: newInventory,
+      resources: {
+        ...state.resources,
+        credits: state.resources.credits + item.value,
+      },
+    };
+  });
+  return sold;
 }
 

--- a/src/game/shop.test.ts
+++ b/src/game/shop.test.ts
@@ -1,34 +1,36 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { useGameStore, initialState } from './state/store';
-import { buyConsumable, buyUpgrade } from './shop';
+import { buyItem, buyUpgrade } from './shop';
+import { sellItem } from './items';
 
 describe('shop actions', () => {
   beforeEach(() => {
     useGameStore.setState(initialState);
   });
 
-  it('buying consumable costs credits and adds to inventory', () => {
+  it('buying item costs credits and adds to inventory', () => {
     useGameStore.setState((s) => ({
       ...s,
       resources: { ...s.resources, credits: 100 },
     }));
-    const success = buyConsumable('medkit_s');
+    const success = buyItem('medkit_s');
     expect(success).toBe(true);
     const state = useGameStore.getState();
     expect(state.resources.credits).toBe(50);
     expect(state.inventory.medkit_s).toBe(1);
   });
 
-  it('buying data-priced consumable costs data and adds to inventory', () => {
+  it('selling item grants credits and removes it from inventory', () => {
     useGameStore.setState((s) => ({
       ...s,
-      resources: { ...s.resources, data: 30 },
+      inventory: { medkit_s: 1 },
+      resources: { ...s.resources, credits: 0 },
     }));
-    const success = buyConsumable('medkit_m');
+    const success = sellItem('medkit_s');
     expect(success).toBe(true);
     const state = useGameStore.getState();
-    expect(state.resources.data).toBe(5);
-    expect(state.inventory.medkit_m).toBe(1);
+    expect(state.resources.credits).toBe(50);
+    expect(state.inventory.medkit_s).toBeUndefined();
   });
 
   it('buying upgrade marks owned and updates stats', () => {

--- a/src/game/shop.ts
+++ b/src/game/shop.ts
@@ -2,36 +2,19 @@ import { useGameStore } from './state/store';
 import { getItem } from '../data/items';
 import { getUpgrade } from '../data/upgrades';
 
-export function buyConsumable(itemId: string): boolean {
+export function buyItem(itemId: string): boolean {
   const item = getItem(itemId);
-  if (!item || item.type !== 'consumable') return false;
+  if (!item) return false;
   if (item.source === 'loot-only') return false;
-  const priceCredits = item.buyPriceCredits ?? 0;
-  const priceData = item.buyPriceData;
   let success = false;
   useGameStore.setState((state) => {
-    if (priceData !== undefined) {
-      if (state.resources.data < priceData) return state;
-      success = true;
-      return {
-        ...state,
-        resources: {
-          ...state.resources,
-          data: state.resources.data - priceData,
-        },
-        inventory: {
-          ...state.inventory,
-          [itemId]: (state.inventory[itemId] ?? 0) + 1,
-        },
-      };
-    }
-    if (state.resources.credits < priceCredits) return state;
+    if (state.resources.credits < item.value) return state;
     success = true;
     return {
       ...state,
       resources: {
         ...state.resources,
-        credits: state.resources.credits - priceCredits,
+        credits: state.resources.credits - item.value,
       },
       inventory: {
         ...state.inventory,

--- a/src/ui/tabs/ExplorationTab.tsx
+++ b/src/ui/tabs/ExplorationTab.tsx
@@ -1,7 +1,7 @@
 import { useGameStore } from '../../game/state/store';
 import { locations, getLocation } from '../../data/locations';
 import { getEnemyById } from '../../data/enemies';
-import { getItem } from '../../data/items';
+import { getItem, ITEM_TYPE_ICONS } from '../../data/items';
 import { setLocation, rollExplorationEvent, clearEncounter } from '../../game/exploration';
 import Card from '../components/Card';
 import SectionHeader from '../components/SectionHeader';
@@ -35,11 +35,11 @@ export default function ExplorationTab() {
             <div className="text-sm">
               Loot:{' '}
               {loc.lootTable
-                ?.map((d) =>
-                  d.itemId === 'credits'
-                    ? '💰'
-                    : getItem(d.itemId)?.iconText ?? d.itemId,
-                )
+                ?.map((d) => {
+                  if (d.itemId === 'credits') return '💰';
+                  const item = getItem(d.itemId);
+                  return item ? ITEM_TYPE_ICONS[item.type] : d.itemId;
+                })
                 .join(' ')}
             </div>
             <ButtonNeon onClick={() => setLocation(loc.id)}>Enter</ButtonNeon>

--- a/src/ui/tabs/StoreTab.tsx
+++ b/src/ui/tabs/StoreTab.tsx
@@ -1,6 +1,11 @@
-import { items, getItem } from '../../data/items';
+import {
+  items,
+  getItem,
+  ITEM_TYPE_ICONS,
+  type ItemType,
+} from '../../data/items';
 import { useGameStore } from '../../game/state/store';
-import { buyConsumable } from '../../game/shop';
+import { buyItem } from '../../game/shop';
 import { showToast } from '../Toast';
 import { useState } from 'react';
 import Card from '../components/Card';
@@ -9,22 +14,25 @@ import SectionHeader from '../components/SectionHeader';
 import Modal from '../components/Modal';
 
 export default function StoreTab() {
-  const resources = useGameStore((s) => s.resources);
-  const credits = resources.credits;
-  const data = resources.data;
-  const consumables = items.filter(
-    (i) =>
-      i.type === 'consumable' &&
-      (i.source === 'shop-only' || i.source === 'both')
+  const credits = useGameStore((s) => s.resources.credits);
+  const categories: { id: ItemType; label: string }[] = [
+    { id: 'consumable', label: 'Consumables' },
+    { id: 'weapon', label: 'Weapons' },
+    { id: 'armor', label: 'Armor' },
+    { id: 'upgrade', label: 'Upgrades' },
+    { id: 'misc', label: 'Misc' },
+  ];
+  const [category, setCategory] = useState<ItemType>('consumable');
+  const available = items.filter(
+    (i) => i.type === category && i.source !== 'loot-only'
   );
-
   const [pending, setPending] = useState<string | null>(null);
 
   const confirmPurchase = () => {
     if (!pending) return;
     const item = getItem(pending);
     if (!item) return;
-    const success = buyConsumable(pending);
+    const success = buyItem(pending);
     if (success) {
       showToast(`Purchased: ${item.name}`);
     }
@@ -36,28 +44,29 @@ export default function StoreTab() {
   return (
     <Card className="space-y-4 p-4">
       <SectionHeader>Store</SectionHeader>
+      <div className="flex gap-2">
+        {categories.map((c) => (
+          <ButtonNeon
+            key={c.id}
+            variant={category === c.id ? 'success' : 'neutral'}
+            onClick={() => setCategory(c.id)}
+          >
+            {c.label}
+          </ButtonNeon>
+        ))}
+      </div>
       <ul className="space-y-2">
-        {consumables.map((item) => (
+        {available.map((item) => (
           <li key={item.id} className="flex items-center justify-between">
             <div>
               <div>
-                {item.iconText} {item.name}
+                {ITEM_TYPE_ICONS[item.type]} {item.name}
               </div>
-              {item.description && (
-                <div className="text-sm text-neon-cyan">{item.description}</div>
-              )}
-              <div className="text-sm text-neon-cyan">
-                {item.buyPriceData
-                  ? `Data: ${item.buyPriceData}`
-                  : `Credits: ${item.buyPriceCredits ?? 0}`}
-              </div>
+              <div className="text-sm text-neon-cyan">{item.description}</div>
+              <div className="text-sm text-neon-cyan">Credits: {item.value}</div>
             </div>
             <ButtonNeon
-              disabled={
-                item.buyPriceData
-                  ? data < item.buyPriceData
-                  : credits < (item.buyPriceCredits ?? 0)
-              }
+              disabled={credits < item.value}
               onClick={() => setPending(item.id)}
             >
               Buy
@@ -81,9 +90,7 @@ export default function StoreTab() {
       >
         {selectedItem && (
           <div>
-            Buy {selectedItem.name} for{' '}
-            {selectedItem.buyPriceData ?? selectedItem.buyPriceCredits ?? 0}{' '}
-            {selectedItem.buyPriceData ? 'data' : 'credits'}?
+            Buy {selectedItem.name} for {selectedItem.value} credits?
           </div>
         )}
       </Modal>


### PR DESCRIPTION
## Summary
- require description and value for all items and add type icons
- allow selling inventory items for credits and show item details
- redesign store with category tabs and item descriptions

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68987123f7c483319f52de61624336ae