### PR TITLE
feat: add world districts and save migration

### DIFF
--- a/src/data/world.ts
+++ b/src/data/world.ts
@@ -1,0 +1,134 @@
+export type DistrictStatus = 'locked' | 'available' | 'active';
+
+export interface DistrictAction {
+  id: string;
+  name: string;
+  kind: 'combat' | 'hacking' | 'scavenge';
+  minLevel: number;
+  baseDurationMs: number;
+  rewards: {
+    xpSkill: 'combat' | 'hacking' | 'exploration';
+    xp: number;
+    credits?: { min: number; max: number };
+    data?: { min: number; max: number };
+  };
+  loot?: { itemId: string; chance: number }[];
+  iconText?: string;
+}
+
+export interface District {
+  id: string;
+  name: string;
+  description: string;
+  unlockLevel: number;
+  enemies?: string[];
+  lootPreview?: string[];
+  actions: DistrictAction[];
+}
+
+export const districts: District[] = [
+  {
+    id: 'neon_market',
+    name: 'Neon Market',
+    description: 'Bustling bazaar of lights and shady deals.',
+    unlockLevel: 1,
+    actions: [
+      {
+        id: 'market_scavenge',
+        name: 'Market Scavenge',
+        kind: 'scavenge',
+        minLevel: 1,
+        baseDurationMs: 5000,
+        rewards: {
+          xpSkill: 'exploration',
+          xp: 5,
+          credits: { min: 1, max: 5 },
+        },
+        iconText: '🛒',
+      },
+      {
+        id: 'public_terminals',
+        name: 'Public Terminals',
+        kind: 'hacking',
+        minLevel: 1,
+        baseDurationMs: 6000,
+        rewards: {
+          xpSkill: 'hacking',
+          xp: 6,
+          data: { min: 1, max: 3 },
+        },
+        iconText: '💻',
+      },
+    ],
+  },
+  {
+    id: 'back_alley',
+    name: 'Back Alley',
+    description: 'Where gangs lurk in the shadows.',
+    unlockLevel: 5,
+    enemies: ['street_thug'],
+    actions: [
+      {
+        id: 'street_patrol',
+        name: 'Street Patrol',
+        kind: 'combat',
+        minLevel: 1,
+        baseDurationMs: 7000,
+        rewards: {
+          xpSkill: 'combat',
+          xp: 10,
+          credits: { min: 5, max: 15 },
+        },
+        iconText: '👊',
+      },
+    ],
+  },
+  {
+    id: 'skyline_plaza',
+    name: 'Skyline Plaza',
+    description: 'High-rise hub with lucrative opportunities.',
+    unlockLevel: 12,
+    enemies: ['street_thug', 'cyber_rat'],
+    actions: [
+      {
+        id: 'plaza_scavenge',
+        name: 'Plaza Scavenge',
+        kind: 'scavenge',
+        minLevel: 1,
+        baseDurationMs: 7000,
+        rewards: {
+          xpSkill: 'exploration',
+          xp: 15,
+          credits: { min: 10, max: 25 },
+        },
+        iconText: '🗑️',
+      },
+      {
+        id: 'corporate_network',
+        name: 'Corporate Network',
+        kind: 'hacking',
+        minLevel: 1,
+        baseDurationMs: 8000,
+        rewards: {
+          xpSkill: 'hacking',
+          xp: 20,
+          data: { min: 5, max: 15 },
+        },
+        iconText: '🛰️',
+      },
+      {
+        id: 'security_showdown',
+        name: 'Security Showdown',
+        kind: 'combat',
+        minLevel: 1,
+        baseDurationMs: 9000,
+        rewards: {
+          xpSkill: 'combat',
+          xp: 25,
+          credits: { min: 20, max: 40 },
+        },
+        iconText: '⚔️',
+      },
+    ],
+  },
+];

--- a/src/game/save/save.ts
+++ b/src/game/save/save.ts
@@ -1,11 +1,12 @@
 import { GameState, initialState } from '../state/store';
 import { getNextLevelXp } from '../skills';
 import { calculateBonuses } from '../items';
+import { districts } from '../../data/world';
 
 const DB_NAME = 'cyber-idle';
 const STORE_NAME = 'game';
 const SAVE_KEY = 'state';
-const SAVE_VERSION = 1;
+const SAVE_VERSION = 2;
 
 interface PersistedData {
   version: number;
@@ -49,7 +50,12 @@ export async function loadGame(): Promise<GameState | null> {
         combat: { ...initialState.combat, ...s.combat },
         exploration: { ...initialState.exploration, ...s.exploration },
         meta: { ...initialState.meta, ...s.meta },
+        world: { ...initialState.world, ...s.world },
       };
+      if (!merged.world.activeDistrictId) {
+        merged.world.activeDistrictId =
+          districts.find((d) => merged.playerLevel >= d.unlockLevel)?.id ?? null;
+      }
       if (typeof merged.playerLevel !== 'number') merged.playerLevel = 1;
       if (typeof merged.playerXP !== 'number') merged.playerXP = 0;
       merged.playerXPToNextLevel =

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { districts } from '../../data/world';
 
 export interface GameState {
   resources: { credits: number; data: number };
@@ -54,6 +55,7 @@ export interface GameState {
     recentLog: string[];
   };
   meta: { lastSaveTimestamp: number | null };
+  world: { activeDistrictId: string | null };
 }
 
 export const initialState: GameState = {
@@ -86,6 +88,17 @@ export const initialState: GameState = {
     recentLog: [],
   },
   meta: { lastSaveTimestamp: null },
+  world: { activeDistrictId: districts[0]?.id ?? null },
 };
 
 export const useGameStore = create<GameState>(() => initialState);
+
+export function setActiveDistrict(id: string | null): void {
+  useGameStore.setState((s) => ({
+    world: { ...s.world, activeDistrictId: id },
+  }));
+}
+
+export function getDistrictById(id: string) {
+  return districts.find((d) => d.id === id);
+}


### PR DESCRIPTION
## Summary
- add world data model with three starter districts and actions
- track active district in store with helpers
- migrate saves to include active district and increment version

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d38611f08331b2b4315d2a320e19