### PR TITLE
feat: overhaul map and location ui

### DIFF
--- a/public/world-map.svg
+++ b/public/world-map.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" />
+  <g stroke="#0ff" stroke-opacity="0.2">
+    <path d="M0 100h800" />
+    <path d="M0 200h800" />
+    <path d="M0 300h800" />
+    <path d="M0 400h800" />
+    <path d="M0 500h800" />
+    <path d="M100 0v600" />
+    <path d="M200 0v600" />
+    <path d="M300 0v600" />
+    <path d="M400 0v600" />
+    <path d="M500 0v600" />
+    <path d="M600 0v600" />
+    <path d="M700 0v600" />
+  </g>
+</svg>

--- a/src/game/state/store.ts
+++ b/src/game/state/store.ts
@@ -94,7 +94,7 @@ export const initialState: GameState = {
     recentLog: [],
   },
   meta: { lastSaveTimestamp: null },
-  world: { activeDistrictId: districts[0]?.id ?? null },
+  world: { activeDistrictId: null },
 };
 
 export const useGameStore = create<GameState>(() => initialState);

--- a/src/ui/AppShell.test.tsx
+++ b/src/ui/AppShell.test.tsx
@@ -2,16 +2,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import AppShell from './AppShell';
 
 describe('AppShell', () => {
-  it('shows HUD and switches tabs', () => {
+  it('renders map by default and switches tabs', () => {
     render(<AppShell />);
-    expect(screen.getByText('Credits: 0')).toBeInTheDocument();
-    expect(screen.getByText('Lvl 1')).toBeInTheDocument();
-    expect(screen.getByText('Hacking L1')).toBeInTheDocument();
-    expect(screen.getByText('Combat L1')).toBeInTheDocument();
-    expect(screen.getByText('Exploration L1')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Start' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Combat' })).toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'Map' }));
-    expect(screen.getAllByText('Neon Market')[0]).toBeInTheDocument();
+    // breadcrumb shows Mapa
+    expect(screen.getAllByText('Mapa')[0]).toBeInTheDocument();
+    // switch to inventory via bottom nav
+    fireEvent.click(screen.getByRole('button', { name: '🎒' }));
+    expect(screen.getByText('Equipped')).toBeInTheDocument();
   });
 });

--- a/src/ui/components/ActiveActionBar.tsx
+++ b/src/ui/components/ActiveActionBar.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useGameStore, getDistrictById } from '../../game/state/store';
+import { getHackingAction } from '../../data/hacking';
+import { getDistrictActionDuration } from '../../game/district';
+import ProgressBarNeon from './ProgressBarNeon';
+
+export default function ActiveActionBar() {
+  const hackingState = useGameStore((s) => s.hackingState);
+  const districtRuntime = useGameStore((s) => s.districtRuntime);
+  const activeDistrictId = useGameStore((s) => s.world.activeDistrictId);
+  const gameState = useGameStore();
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 200);
+    return () => clearInterval(id);
+  }, []);
+
+  let name: string | null = null;
+  let icon: string | null = null;
+  let startedAt: number | undefined;
+  let duration = 0;
+
+  if (hackingState.isRunning && hackingState.currentActionId) {
+    const action = getHackingAction(hackingState.currentActionId);
+    if (action) {
+      name = action.name;
+      icon = action.iconText;
+      startedAt = hackingState.lastStartAt;
+      duration = action.baseDurationMs /
+        gameState.hacking.timeMultiplier /
+        gameState.bonuses.hackingSpeed;
+    }
+  } else if (districtRuntime.isRunning && districtRuntime.runningActionId && activeDistrictId) {
+    const district = getDistrictById(activeDistrictId);
+    const action = district?.actions.find((a) => a.id === districtRuntime.runningActionId);
+    if (district && action) {
+      name = action.name;
+      icon = action.iconText ?? null;
+      startedAt = districtRuntime.startedAt;
+      duration = getDistrictActionDuration(action, gameState);
+    }
+  }
+
+  if (!name || !startedAt) return null;
+
+  const progress = Math.min(100, ((now - startedAt) / duration) * 100);
+  const remaining = Math.max(0, duration - (now - startedAt));
+  const seconds = (remaining / 1000).toFixed(1);
+
+  return (
+    <div className="fixed bottom-12 md:bottom-0 left-0 md:left-20 right-0 z-20 bg-gray-900/90 p-2">
+      <div className="flex items-center gap-2 text-sm text-neon-cyan">
+        {icon && <span>{icon}</span>}
+        <span className="flex-1 truncate">{name}</span>
+        <span>{seconds}s</span>
+      </div>
+      <ProgressBarNeon percentage={progress} />
+    </div>
+  );
+}

--- a/src/ui/location/LocationView.tsx
+++ b/src/ui/location/LocationView.tsx
@@ -1,19 +1,35 @@
 import { useEffect, useState } from 'react';
-import { getDistrictById, setActiveDistrict, useGameStore } from '../../game/state/store';
-import { startDistrictAction, stopDistrictAction, getDistrictActionDuration } from '../../game/district';
+import {
+  useGameStore,
+  getDistrictById,
+  setActiveDistrict,
+} from '../../game/state/store';
+import {
+  startDistrictAction,
+  stopDistrictAction,
+  getDistrictActionDuration,
+} from '../../game/district';
 import ButtonNeon from '../components/ButtonNeon';
 import Card from '../components/Card';
 import ProgressBarNeon from '../components/ProgressBarNeon';
+import { ITEM_TYPE_ICONS, getItem } from '../../data/items';
 
-interface Props {
-  onBack: () => void;
-}
+const localTabs = [
+  { key: 'missions', label: 'Misje' },
+  { key: 'combat', label: 'Walka' },
+  { key: 'hacking', label: 'Hakowanie' },
+  { key: 'special', label: 'Special' },
+] as const;
 
-export default function LocationView({ onBack }: Props) {
+type LocalTab = (typeof localTabs)[number]['key'];
+
+export default function LocationView() {
   const activeDistrictId = useGameStore((s) => s.world.activeDistrictId);
   const runtime = useGameStore((s) => s.districtRuntime);
   const state = useGameStore();
   const [now, setNow] = useState(Date.now());
+  const [tab, setTab] = useState<LocalTab>('missions');
+
   useEffect(() => {
     const id = setInterval(() => setNow(Date.now()), 200);
     return () => clearInterval(id);
@@ -22,60 +38,106 @@ export default function LocationView({ onBack }: Props) {
   const district = activeDistrictId ? getDistrictById(activeDistrictId) : null;
   if (!district) return null;
 
-  const handleLeave = () => {
+  const handleBack = () => {
     stopDistrictAction();
     setActiveDistrict(null);
-    onBack();
   };
 
+  const filtered = district.actions.filter((a) => {
+    if (tab === 'missions') return true;
+    if (tab === 'special') return a.kind === 'scavenge';
+    return a.kind === tab;
+  });
+
   return (
-    <div className="p-4 space-y-4">
-      <div className="flex items-center space-x-2">
-        <button className="text-neon-cyan" onClick={onBack}>
-          Map
-        </button>
-        <span>&gt;</span>
-        <span>{district.name}</span>
-        <div className="flex-1" />
-        <ButtonNeon onClick={handleLeave}>Leave</ButtonNeon>
-      </div>
-      <p>{district.description}</p>
-      <div className="grid gap-2">
-        {district.actions.map((a) => {
-          const running = runtime.isRunning && runtime.runningActionId === a.id;
-          const duration = getDistrictActionDuration(a, state);
-          const progress = running && runtime.startedAt
-            ? Math.min(100, ((now - runtime.startedAt) / duration) * 100)
-            : 0;
-          return (
-            <Card key={a.id} className="p-2 space-y-2">
-              <div className="flex justify-between">
-                <div>
-                  <div className="font-semibold">
-                    {a.iconText && <span className="mr-1">{a.iconText}</span>}
-                    {a.name}
+    <div className="flex h-full">
+      {/* Side tabs on desktop */}
+      <nav className="hidden w-32 flex-col border-r border-neon-magenta p-2 md:flex">
+        {localTabs.map((t) => (
+          <button
+            key={t.key}
+            onClick={() => setTab(t.key)}
+            className={`p-2 text-left ${
+              tab === t.key ? 'text-neon-magenta' : 'text-neon-cyan'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* Header */}
+        <div className="flex items-center gap-2">
+          <button onClick={handleBack} className="text-neon-cyan">
+            ←
+          </button>
+          <span>Mapa &gt; {district.name}</span>
+        </div>
+        {/* Tabs for mobile */}
+        <div className="flex gap-2 md:hidden">
+          {localTabs.map((t) => (
+            <button
+              key={t.key}
+              onClick={() => setTab(t.key)}
+              className={`flex-1 p-2 text-sm ${
+                tab === t.key ? 'text-neon-magenta' : 'text-neon-cyan'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+        <p>{district.description}</p>
+        <div className="grid gap-2">
+          {filtered.map((a) => {
+            const running =
+              runtime.isRunning && runtime.runningActionId === a.id;
+            const duration = getDistrictActionDuration(a, state);
+            const progress =
+              running && runtime.startedAt
+                ? Math.min(100, ((now - runtime.startedAt) / duration) * 100)
+                : 0;
+            return (
+              <Card key={a.id} className="p-2 space-y-2">
+                <div className="flex justify-between">
+                  <div>
+                    <div className="font-semibold">
+                      {a.iconText && <span className="mr-1">{a.iconText}</span>}
+                      {a.name}
+                    </div>
+                    <div className="text-xs">
+                      {a.kind} · L{a.minLevel} · {(duration / 1000).toFixed(1)}s
+                    </div>
                   </div>
-                  <div className="text-xs">
-                    {a.kind} · L{a.minLevel} · {(duration / 1000).toFixed(1)}s
-                  </div>
+                  {running ? (
+                    <ButtonNeon onClick={stopDistrictAction}>Stop</ButtonNeon>
+                  ) : (
+                    <ButtonNeon onClick={() => startDistrictAction(a.id)}>
+                      Start
+                    </ButtonNeon>
+                  )}
                 </div>
-                {running ? (
-                  <ButtonNeon onClick={stopDistrictAction}>Stop</ButtonNeon>
-                ) : (
-                  <ButtonNeon onClick={() => startDistrictAction(a.id)}>
-                    Start
-                  </ButtonNeon>
+                {running && <ProgressBarNeon percentage={progress} />}
+                {a.loot && (
+                  <div className="flex gap-1 text-sm">
+                    {a.loot.map((l) => {
+                      const item = getItem(l.itemId);
+                      return (
+                        <span
+                          key={l.itemId}
+                          title={`${item?.name ?? l.itemId} (${Math.round(
+                            l.chance * 100
+                          )}%)`}
+                        >
+                          {item ? ITEM_TYPE_ICONS[item.type] : '🎁'}
+                        </span>
+                      );
+                    })}
+                  </div>
                 )}
-              </div>
-              {running && <ProgressBarNeon percentage={progress} />}
-            </Card>
-          );
-        })}
-      </div>
-      <div>
-        <h3 className="font-bold mb-1">Recent</h3>
-        <div className="min-h-[3rem] text-sm">
-          {/* Placeholder for logs */}
+              </Card>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/ui/tabs/MapTab.tsx
+++ b/src/ui/tabs/MapTab.tsx
@@ -1,90 +1,59 @@
-import { useState } from 'react';
-import { districts, type DistrictStatus } from '../../data/world';
-import { getEnemyById } from '../../data/enemies';
+import { districts } from '../../data/world';
 import { useGameStore, setActiveDistrict } from '../../game/state/store';
 import { showToast } from '../Toast';
 import LocationView from '../location/LocationView';
 
+const districtPositions: Record<string, { x: number; y: number }> = {
+  neon_market: { x: 30, y: 60 },
+  back_alley: { x: 55, y: 45 },
+  skyline_plaza: { x: 75, y: 30 },
+};
+
 export default function MapTab() {
   const playerLevel = useGameStore((s) => s.playerLevel);
   const activeDistrictId = useGameStore((s) => s.world.activeDistrictId);
-  const [view, setView] = useState<'map' | 'location'>('map');
 
-  if (view === 'location' && activeDistrictId) {
-    return <LocationView onBack={() => setView('map')} />;
+  if (activeDistrictId) {
+    return <LocationView />;
   }
 
   return (
-    <div className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 md:grid-cols-3">
+    <div
+      className="relative h-full w-full bg-center bg-cover"
+      style={{ backgroundImage: 'url(/world-map.svg)' }}
+    >
       {districts.map((d) => {
-        const status: DistrictStatus =
-          activeDistrictId === d.id
-            ? 'active'
-            : playerLevel >= d.unlockLevel
-              ? 'available'
-              : 'locked';
-
+        const pos = districtPositions[d.id];
+        if (!pos) return null;
+        const status =
+          playerLevel >= d.unlockLevel ? 'available' : 'locked';
         const handleClick = () => {
           if (status === 'locked') {
             showToast(`Requires Level ${d.unlockLevel}`);
           } else {
             setActiveDistrict(d.id);
-            setView('location');
           }
         };
-
         return (
           <div
             key={d.id}
-            onClick={handleClick}
-            className={`group relative cursor-pointer border p-4 transition ${
-              status === 'locked'
-                ? 'opacity-50'
-                : 'hover:shadow-[0_0_8px_#ff00ff]'
-            } ${
-              status === 'active'
-                ? 'border-neon-magenta animate-pulse'
-                : status === 'available'
-                  ? 'border-neon-cyan'
-                  : 'border-gray-700'
-            }`}
+            className="group absolute -translate-x-1/2 -translate-y-1/2"
+            style={{ left: `${pos.x}%`, top: `${pos.y}%` }}
           >
-            {status === 'locked' && (
-              <span className="absolute right-2 top-2">🔒</span>
-            )}
-            <div className="font-bold">{d.name}</div>
-            <div className="text-sm">{d.description}</div>
-            {status === 'locked' && (
-              <div className="mt-2 text-xs">Requires L{d.unlockLevel}</div>
-            )}
-            {d.enemies && (
-              <div className="mt-1 text-xs">
-                Enemies:{' '}
-                {d.enemies
-                  .map((e) => getEnemyById(e)?.name ?? e)
-                  .join(', ')}
-              </div>
-            )}
-            {d.actions.some((a) => a.iconText) && (
-              <div className="mt-1 text-lg">
-                {d.actions
-                  .map((a) => a.iconText)
-                  .filter(Boolean)
-                  .join(' ')}
-              </div>
-            )}
-            <div className="pointer-events-none absolute left-1/2 top-full z-10 hidden w-48 -translate-x-1/2 rounded border border-neon-magenta bg-surface p-2 text-xs group-hover:block">
+            <button
+              onClick={handleClick}
+              className={`h-6 w-6 rounded-full border-2 ${
+                status === 'locked'
+                  ? 'border-gray-700 bg-gray-800'
+                  : 'border-neon-cyan bg-gray-900 hover:shadow-[0_0_8px_#0ff]'
+              }`}
+            >
+              {status === 'locked' && <span className="text-xs">🔒</span>}
+            </button>
+            <div className="pointer-events-none absolute left-1/2 top-full z-10 hidden w-40 -translate-x-1/2 rounded border border-neon-magenta bg-surface p-2 text-xs group-hover:block">
               <div className="font-bold">{d.name}</div>
               <p className="mb-1">{d.description}</p>
               <div>Requires L{d.unlockLevel}</div>
-              {d.actions.some((a) => a.iconText) && (
-                <div className="mt-1">
-                  {d.actions
-                    .map((a) => a.iconText)
-                    .filter(Boolean)
-                    .join(' ')}
-                </div>
-              )}
             </div>
           </div>
         );


### PR DESCRIPTION
## Summary
- add responsive sidebar and mobile nav with cyberpunk styling
- implement hotspot-based world map and enriched location view with action tabs
- display persistent active action bar for running hacks and district actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898dd0675d88331a9f80316e79e7cc8